### PR TITLE
waveform: Refactor timing imports

### DIFF
--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -11,9 +11,7 @@ from nitypes.waveform._scaling import (
     NoneScaleMode,
     ScaleMode,
 )
-from nitypes.waveform._timing._base import BaseTiming, SampleIntervalMode
-from nitypes.waveform._timing._precision import PrecisionTiming
-from nitypes.waveform._timing._standard import Timing
+from nitypes.waveform._timing import BaseTiming, PrecisionTiming, SampleIntervalMode, Timing
 
 __all__ = [
     "AnalogWaveform",

--- a/src/nitypes/waveform/_analog_waveform.py
+++ b/src/nitypes/waveform/_analog_waveform.py
@@ -14,9 +14,7 @@ from nitypes.waveform._extended_properties import (
     ExtendedPropertyDictionary,
 )
 from nitypes.waveform._scaling import NO_SCALING, ScaleMode
-from nitypes.waveform._timing._conversion import convert_timing
-from nitypes.waveform._timing._precision import PrecisionTiming
-from nitypes.waveform._timing._standard import Timing
+from nitypes.waveform._timing import PrecisionTiming, Timing, convert_timing
 
 if sys.version_info < (3, 10):
     import array as std_array

--- a/src/nitypes/waveform/_timing/__init__.py
+++ b/src/nitypes/waveform/_timing/__init__.py
@@ -1,1 +1,8 @@
 """Waveform timing data types for NI Python APIs."""
+
+from nitypes.waveform._timing._base import BaseTiming, SampleIntervalMode
+from nitypes.waveform._timing._conversion import convert_timing
+from nitypes.waveform._timing._precision import PrecisionTiming
+from nitypes.waveform._timing._standard import Timing
+
+__all__ = ["BaseTiming", "convert_timing", "PrecisionTiming", "SampleIntervalMode", "Timing"]

--- a/tests/unit/waveform/_timing/test_conversion.py
+++ b/tests/unit/waveform/_timing/test_conversion.py
@@ -6,7 +6,7 @@ import sys
 import hightime as ht
 
 from nitypes.waveform import PrecisionTiming, SampleIntervalMode, Timing
-from nitypes.waveform._timing._conversion import convert_timing
+from nitypes.waveform._timing import convert_timing
 
 if sys.version_info >= (3, 11):
     from typing import assert_type


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allow importing from `nitypes.waveform._timing`.

### Why should this Pull Request be merged?

Only code inside the `_timing` subpackage should care how the `_timing` subpackage is structured.

### What testing has been done?

Ran tests