### PR TITLE
waveform: Implement loading data into existing waveform

### DIFF
--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -7,6 +7,24 @@ class TimingMismatchError(RuntimeError):
     pass
 
 
+def input_array_data_type_mismatch(input_dtype: object, waveform_dtype: object) -> TypeError:
+    """Create a TypeError for an input array data type mismatch."""
+    return TypeError(
+        "The data type of the input array must match the waveform data type.\n\n"
+        f"Input array data type: {input_dtype}\n"
+        f"Waveform data type: {waveform_dtype}"
+    )
+
+
+def input_waveform_data_type_mismatch(input_dtype: object, waveform_dtype: object) -> TypeError:
+    """Create a TypeError for an input waveform data type mismatch."""
+    return TypeError(
+        "The data type of the input waveform must match the waveform data type.\n\n"
+        f"Input waveform data type: {input_dtype}\n"
+        f"Waveform data type: {waveform_dtype}"
+    )
+
+
 def no_timestamp_information() -> RuntimeError:
     """Create a RuntimeError for waveform timing with no timestamp information."""
     return RuntimeError(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `AnalogWaveform.load_data`, which allows overwriting or reassigning the waveform data array.

By default, this overwrites the waveform's data array (which might be backed by shared memory). If you specify `copy=False`, it takes ownership of the passed-in array (this is zero copy, but doesn't reuse shared memory).

You can specify an array subset using the `start_index` and `sample_count` parameters. I filed [AB#3111366](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3111366) - Consider removing start_index from AnalogWaveform API because I think we should revisit whether this is necessary once we have some run time with waveforms backed by shared memory.

### Why should this Pull Request be merged?

Closes [AB#3106621](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3106621) - Add load data into existing waveform

### What testing has been done?

Ran unit tests.