### PR TITLE
docs: Remove Sphinx --keep-going option

### DIFF
--- a/.github/workflows/check_docs.yml
+++ b/.github/workflows/check_docs.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install nitypes (with docs)
         run: poetry install -v --only main,docs
       - name: Generate docs
-        run:  poetry run sphinx-build docs docs/_build -b html -W --keep-going
+        run:  poetry run sphinx-build docs docs/_build -b html -W
       - name: Upload docs artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Remove `--keep-going` from the Sphinx command line

### Why should this Pull Request be merged?

`--keep-going` is always enabled in Sphinx 8.1+: https://www.sphinx-doc.org/en/master/man/sphinx-build.html#cmdoption-sphinx-build-keep-going

### What testing has been done?

PR build
