### PR TITLE
renovate: Pin GitHub Action digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
     "config:recommended",
     ":maintainLockFilesWeekly",
     ":automergePatch",
-    "schedule:automergeDaily"
+    "schedule:automergeDaily",
+    "helpers:pinGitHubActionDigestsToSemver"
   ]
 }


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enable [helpers:pinGitHubActionDigestsToSemver](https://docs.renovatebot.com/presets-helpers/#helperspingithubactiondigeststosemver)

### Why should this Pull Request be merged?

Pinning GitHub action digests improves build reproducibility and is a security best practice.

### What testing has been done?

None