### PR TITLE
pyproject.toml: Fix PEP 660 builds by setting build-system to use poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ addopts = "--doctest-modules --doctest-plus --strict-markers"
 testpaths = ["src/nitypes", "tests"]
 
 [build-system]
-requires = ["poetry>=1.2"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.8"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.mypy]
 files = "examples/,scripts/,src/,tests/"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change the build system from `poetry` to `poetry-core`.

### Why should this Pull Request be merged?

Enables clients to install nitypes in editable mode, outside of this project.

Fixes #44 

### What testing has been done?

```powershell
cd $env:TEMP
python -m venv .edit_nitypes
.\.edit_nitypes\Scripts\pip.exe install -e C:\dev\nitypes-python\
```