### PR TITLE
github: Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
         uses: ni/python-actions/setup-poetry@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
       - name: Get version from pyproject.toml
         id: get-version
-        run: version=`poetry version --short` >> "$GITHUB_OUTPUT"
+        run: echo version=`poetry version --short` >> "$GITHUB_OUTPUT"
       - name: Bump the version number
         id: bump-version
         run: |


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a GitHub Actions workflow to publish the `nitypes` package to PyPI using GitHub as a PyPI "Trusted Publisher".

### Why should this Pull Request be merged?

Enable publishing the package.

### What testing has been done?

Published to TestPyPI:
- https://github.com/ni/nitypes-python/actions/runs/15147102203
- https://test.pypi.org/project/nitypes/

Update version (tested with environment=none):
- https://github.com/ni/nitypes-python/actions/runs/15148593014/job/42590203704
- https://github.com/ni/nitypes-python/pull/57