### PR TITLE
github: Refactor publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,4 +88,4 @@ jobs:
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
       - name: Update project version
-        uses: ni/python-actions/update-project-version@e183aaeec4ffab2bc331bf47093bccc086bc19d3 # users/bkeryan/update-project-version
+        uses: ni/python-actions/update-project-version@c09765bfa2f886e2227f6c2525cb006348736349 # users/bkeryan/update-project-version


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Combine the jobs for deploying to PyPI and TestPyPI.
- Change the default `environment` input to `pypi` so that we don't have to check the event type to handle `on: release`.
- Check that the release tag matches the project version in `pyproject.toml`

I considered moving the URLs to `PYPI_PROJECT_PATH` and `PYPI_UPLOAD_PATH` variables in the repo's `pypi` and `testpypi` environment settings, but I don't want to have to set these for each GitHub repo. I'd rather have it in the workflow so I can copy/paste it or move it to a composite action.

### Why should this Pull Request be merged?

Reduce duplication and make this code more suitable for copy/pasting or refactoring into a composite action.

### What testing has been done?

- `environment=none`: https://github.com/ni/nitypes-python/actions/runs/15174899035
- `environment=testpypi`: https://github.com/ni/nitypes-python/actions/runs/15174932174
   - Note that this fails because the `pypi` and `testpypi` environments only allow deploying from `main` or `releases/*`. I will test it once it's in main.