### PR TITLE
github: Fix publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,12 +6,18 @@ on:
   workflow_dispatch:
     inputs:
       environment:
-        description: The environment to publish to ("pypi", "testpypi", or "none").
-        default: 'pypi'
+        description: The environment to publish to.
+        default: 'none'
         required: true
+        type: choice
+        options:
+          - none
+          - pypi
+          - testpypi
 
 env:
   dist-artifact-name: nitypes-distribution-packages
+  environment: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
   environment-info: |
     {
       "pypi": {
@@ -54,12 +60,13 @@ jobs:
           path: dist/*
   publish_to_pypi:
     name: Publish nitypes to PyPI
-    if: inputs.environment != 'none'
+    if: github.event_name == 'release' || inputs.environment != 'none'
     runs-on: ubuntu-latest
     needs: [build_nitypes]
     environment:
-      name: ${{ inputs.environment }}
-      url: ${{ fromJson(env.environment-info)[inputs.environment].base-url }}/p/nitypes
+      # This logic is duplicated because `name` doesn't support the `env` context.
+      name: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+      url: ${{ fromJson(env.environment-info)[env.environment].base-url }}/p/nitypes
     permissions:
       id-token: write
     steps:
@@ -69,10 +76,10 @@ jobs:
         name: ${{ env.dist-artifact-name }}
         path: dist/
     - run: ls -lR
-    - name: Upload to ${{ inputs.environment }}
+    - name: Upload to ${{ env.environment }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: ${{ fromJson(env.environment-info)[inputs.environment].upload-url }} 
+        repository-url: ${{ fromJson(env.environment-info)[env.environment].upload-url }} 
   update_version:
     name: Update nitypes version
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
         uses: ni/python-actions/setup-poetry@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
       - name: Check project version
         if: github.event_name == 'release'
-        uses: ni/python-actions/check-project-version@c09765bfa2f886e2227f6c2525cb006348736349 # users/bkeryan/update-project-version
+        uses: ni/python-actions/check-project-version@89453df56376aeffcb1e6c69388a5b7413c807f9 # users/bkeryan/update-project-version
       - name: Build distribution packages
         run: poetry build
       - name: Upload build artifacts
@@ -95,4 +95,4 @@ jobs:
       - name: Set up Poetry
         uses: ni/python-actions/setup-poetry@e8f25e9a64426bd431ac124b83df11b76cdf60d5 # v0.1.0
       - name: Update project version
-        uses: ni/python-actions/update-project-version@c09765bfa2f886e2227f6c2525cb006348736349 # users/bkeryan/update-project-version
+        uses: ni/python-actions/update-project-version@89453df56376aeffcb1e6c69388a5b7413c807f9 # users/bkeryan/update-project-version


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

I tested the publish workflow using `workflow_dispatch`, and when I published an actual release, it didn't work because my assumptions about how `workflow_dispatch` inputs are handled for `event_name=='release'` were incorrect.

### Why should this Pull Request be merged?

Make publish workflow work for next release.

### What testing has been done?

Tested by making a release in a personal fork of this repo that publishes to TestPyPI.