### PR TITLE
Implement __reduce__ and add copy/pickling tests.

### DIFF
--- a/src/nitypes/scalar/_scalar.py
+++ b/src/nitypes/scalar/_scalar.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, Union
+from typing import Any, Generic, Union
 
 from typing_extensions import final, TypeVar
 
@@ -125,6 +125,10 @@ class Scalar(Generic[_ScalarType_co]):
             return self.value <= value.value
         else:
             raise TypeError("Comparing Scalar objects of numeric and string types is not permitted")
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Return object state for pickling."""
+        return (self.__class__, (self.value, self.units))
 
     def __repr__(self) -> str:
         """Return repr(self)."""

--- a/tests/unit/scalar/test_scalar.py
+++ b/tests/unit/scalar/test_scalar.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import copy
+import pickle
 from typing import Any
 
 import pytest
@@ -177,3 +179,49 @@ def test___scalar_with_units___get_extended_properties___returns_correct_diction
 
     assert isinstance(prop_dict, ExtendedPropertyDictionary)
     assert prop_dict.get(UNIT_DESCRIPTION) == "watts"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        Scalar(False),
+        Scalar(10),
+        Scalar(20.0),
+        Scalar("value"),
+        Scalar(False, "amps"),
+        Scalar(10, "volts"),
+        Scalar(20.0, "watts"),
+        Scalar("value", ""),
+    ],
+)
+def test___various_values___copy___makes_copy(value: Scalar[_ScalarType_co]) -> None:
+    new_value = copy.copy(value)
+    assert new_value is not value
+    assert new_value == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        Scalar(False),
+        Scalar(10),
+        Scalar(20.0),
+        Scalar("value"),
+        Scalar(False, "amps"),
+        Scalar(10, "volts"),
+        Scalar(20.0, "watts"),
+        Scalar("value", ""),
+    ],
+)
+def test___various_values___pickle_unpickle___makes_copy(value: Scalar[_ScalarType_co]) -> None:
+    new_value = pickle.loads(pickle.dumps(value))
+    assert new_value is not value
+    assert new_value == value
+
+
+def test___timedelta___pickle___references_public_modules() -> None:
+    value = Scalar(123)
+    value_bytes = pickle.dumps(value)
+
+    assert b"nitypes.scalar" in value_bytes
+    assert b"nitypes.scalar._scalar" not in value_bytes


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Implements the `__reduce__()` function to allow for deep copies and pickling.
Adds unit tests to exercise copies and pickling.

### Why should this Pull Request be merged?

Pickling is required for python types to work with the panels
AB#3066182

### What testing has been done?

Unit tests pass
