### PR TITLE
Add Timing.has_sample_interval.

### DIFF
--- a/src/nitypes/waveform/_timing/_timing.py
+++ b/src/nitypes/waveform/_timing/_timing.py
@@ -218,6 +218,11 @@ class Timing(Generic[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]):
         return value
 
     @property
+    def has_sample_interval(self) -> bool:
+        """Indicates whether the waveform timing has a sample interval."""
+        return self._sample_interval is not None
+
+    @property
     def sample_interval(self) -> _TSampleInterval_co:
         """The time interval between samples."""
         value = self._sample_interval

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -45,7 +45,7 @@ def test___empty___no_time_offset() -> None:
 
 
 def test___empty___no_sample_interval() -> None:
-    assert Timing.empty._sample_interval is None
+    assert not Timing.empty.has_sample_interval
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.sample_interval
 
@@ -65,7 +65,7 @@ def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
     assert not timing.has_time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -76,7 +76,7 @@ def test___timestamp___create_with_no_interval___creates_waveform_timing_with_ti
     assert_type(timing, Timing[bt.DateTime, dt.timedelta, dt.timedelta])
     assert timing.timestamp == timestamp
     assert not timing.has_time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -90,7 +90,7 @@ def test___timestamp_and_time_offset___create_with_no_interval___creates_wavefor
     assert_type(timing, Timing[bt.DateTime, bt.TimeDelta, dt.timedelta])
     assert timing.timestamp == timestamp
     assert timing.time_offset == time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -103,7 +103,7 @@ def test___time_offset___create_with_no_interval___creates_waveform_timing_with_
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, dt.timedelta])
     assert not timing.has_timestamp
     assert timing.time_offset == time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -44,7 +44,7 @@ def test___empty___no_time_offset() -> None:
 
 
 def test___empty___no_sample_interval() -> None:
-    assert Timing.empty._sample_interval is None
+    assert not Timing.empty.has_sample_interval
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.sample_interval
 
@@ -64,7 +64,7 @@ def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
     assert not timing.has_time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -75,7 +75,7 @@ def test___timestamp___create_with_no_interval___creates_waveform_timing_with_ti
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert timing.timestamp == timestamp
     assert not timing.has_time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -89,7 +89,7 @@ def test___timestamp_and_time_offset___create_with_no_interval___creates_wavefor
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert timing.timestamp == timestamp
     assert timing.time_offset == time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -102,7 +102,7 @@ def test___time_offset___create_with_no_interval___creates_waveform_timing_with_
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
     assert timing.time_offset == time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -45,7 +45,7 @@ def test___empty___no_time_offset() -> None:
 
 
 def test___empty___no_sample_interval() -> None:
-    assert Timing.empty._sample_interval is None
+    assert not Timing.empty.has_sample_interval
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.sample_interval
 
@@ -65,7 +65,7 @@ def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
     assert not timing.has_time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -76,7 +76,7 @@ def test___timestamp___create_with_no_interval___creates_waveform_timing_with_ti
     assert_type(timing, Timing[ht.datetime, dt.timedelta, dt.timedelta])
     assert timing.timestamp == timestamp
     assert not timing.has_time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -90,7 +90,7 @@ def test___timestamp_and_time_offset___create_with_no_interval___creates_wavefor
     assert_type(timing, Timing[ht.datetime, ht.timedelta, dt.timedelta])
     assert timing.timestamp == timestamp
     assert timing.time_offset == time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
@@ -103,7 +103,7 @@ def test___time_offset___create_with_no_interval___creates_waveform_timing_with_
     assert_type(timing, Timing[dt.datetime, ht.timedelta, dt.timedelta])
     assert not timing.has_timestamp
     assert timing.time_offset == time_offset
-    assert timing._sample_interval is None
+    assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds a new property that returns whether a sample interval has been set on a timing object.

`Timing.has_sample_interval`.

This is similar to other properties like `Timing.has_timestamp` and `Timing.has_time_offset`.

### Why should this Pull Request be merged?

Allows python<-->gRPC code to check if there is a sample interval rather than try-catching an exception.

AB#3161134

### What testing has been done?

I updated the existing unit tests to use this new property. All unit tests pass.
