### PR TITLE
Add __version__ support to nitypes.

### DIFF
--- a/src/nitypes/__init__.py
+++ b/src/nitypes/__init__.py
@@ -1,1 +1,6 @@
 """Data types for NI Python APIs."""
+
+from importlib.metadata import version
+
+
+__version__ = version(__name__)


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds the `__version__` attribute to the `nitypes` package.

### Why should this Pull Request be merged?

[AB#3126428](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3126428)
nitypes should provide `__version__` (GitHub Issue #49)

### What testing has been done?

I ran the following code in the poetry venv with these changes and it returned the correct version:
```
import nitypes
nitypes.__version__
```
