### PR TITLE
waveform: Add narrative documentation for timing and fix `__doctest_requires__` syntax

### DIFF
--- a/src/nitypes/_arguments.py
+++ b/src/nitypes/_arguments.py
@@ -16,7 +16,7 @@ from nitypes._numpy import isdtype as _np_isdtype
 
 # Some of these doctests use types introduced in NumPy 2.0 (np.long and np.ulong) or highlight
 # formatting differences between NumPy 1.x and 2.x (e.g. dtype=int32, 1.23 vs. np.float64(1.23)).
-__doctest_requires__ = {("arg_to_float", "is_dtype", "validate_dtype"): "numpy>=2.0"}
+__doctest_requires__ = {("arg_to_float", "is_dtype", "validate_dtype"): ["numpy>=2.0"]}
 
 
 def arg_to_float(

--- a/src/nitypes/complex/__init__.py
+++ b/src/nitypes/complex/__init__.py
@@ -127,4 +127,4 @@ from nitypes.complex._conversion import convert_complex
 from nitypes.complex._dtypes import ComplexInt32Base, ComplexInt32DType
 
 __all__ = ["convert_complex", "ComplexInt32DType", "ComplexInt32Base"]
-__doctest_requires__ = {".": "numpy>=2.0"}
+__doctest_requires__ = {".": ["numpy>=2.0"]}

--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -86,7 +86,7 @@ Traceback (most recent call last):
 AttributeError: property 'sample_interval' of 'Timing' object has no setter
 
 Instead, if you want to modify the timing information for an existing waveform, you can create a new
-timing object and set the :any:`AnalogWaveform.timing` property:
+timing object and set the :any:`NumericWaveform.timing` property:
 
 >>> wfm.timing = Timing.create_with_regular_interval(
 ...     dt.timedelta(seconds=1e-3), dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc)
@@ -113,7 +113,7 @@ nitypes.waveform.Timing(nitypes.waveform.SampleIntervalMode.REGULAR,
     timestamp=nitypes.bintime.DateTime(2025, 1, 1, 0, 0, tzinfo=datetime.timezone.utc),
     sample_interval=nitypes.bintime.TimeDelta(Decimal('0.000999999999999999966606573')))
 
-If :any:`AnalogWaveform.timing` is not specified for a given waveform, it defaults to the
+If :any:`NumericWaveform.timing` is not specified for a given waveform, it defaults to the
 :any:`Timing.empty` singleton object.
 
 >>> AnalogWaveform().timing

--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -136,7 +136,7 @@ __all__ = [
     "TimingMismatchError",
     "TimingMismatchWarning",
 ]
-__doctest_requires__ = {".": "numpy>=2.0"}
+__doctest_requires__ = {".": ["numpy>=2.0"]}
 
 
 # Hide that it was defined in a helper file


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add narrative documentation for waveform timing.

Fix `__doctest_requires__` syntax. The dict values should be lists, not strings. Using the wrong syntax caused pytest-doctestplus to unconditionally disable the doctests.

### Why should this Pull Request be merged?

Closes [AB#3122152](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3122152)

### What testing has been done?

Ran pytest