### PR TITLE
tests: Add tests for Timing constructor, including type inference

### DIFF
--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -59,7 +59,7 @@ def test___empty___sample_interval_mode_none() -> None:
 ###############################################################################
 # create_with_no_interval
 ###############################################################################
-def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -> None:
+def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
     timing = Timing.create_with_no_interval()
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
@@ -69,7 +69,7 @@ def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___timestamp___create_with_no_interval___creates_waveform_timing_with_timestamp() -> None:
+def test___timestamp___create_with_no_interval___creates_timing_with_timestamp() -> None:
     timestamp = bt.DateTime.now(dt.timezone.utc)
     timing = Timing.create_with_no_interval(timestamp)
 
@@ -80,7 +80,7 @@ def test___timestamp___create_with_no_interval___creates_waveform_timing_with_ti
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___timestamp_and_time_offset___create_with_no_interval___creates_waveform_timing_with_timestamp_and_time_offset() -> (
+def test___timestamp_and_time_offset___create_with_no_interval___creates_timing_with_timestamp_and_time_offset() -> (
     None
 ):
     timestamp = bt.DateTime.now(dt.timezone.utc)
@@ -94,9 +94,7 @@ def test___timestamp_and_time_offset___create_with_no_interval___creates_wavefor
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___time_offset___create_with_no_interval___creates_waveform_timing_with_time_offset() -> (
-    None
-):
+def test___time_offset___create_with_no_interval___creates_timing_with_time_offset() -> None:
     time_offset = bt.TimeDelta(1.23)
     timing = Timing.create_with_no_interval(time_offset=time_offset)
 
@@ -110,7 +108,7 @@ def test___time_offset___create_with_no_interval___creates_waveform_timing_with_
 ###############################################################################
 # create_with_regular_interval
 ###############################################################################
-def test___sample_interval___create_with_regular_interval___creates_waveform_timing_with_sample_interval() -> (
+def test___sample_interval___create_with_regular_interval___creates_timing_with_sample_interval() -> (
     None
 ):
     sample_interval = bt.TimeDelta(1e-3)
@@ -124,7 +122,7 @@ def test___sample_interval___create_with_regular_interval___creates_waveform_tim
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_and_timestamp___create_with_regular_interval___creates_waveform_timing_with_sample_interval_and_timestamp() -> (
+def test___sample_interval_and_timestamp___create_with_regular_interval___creates_timing_with_sample_interval_and_timestamp() -> (
     None
 ):
     sample_interval = bt.TimeDelta(1e-3)
@@ -139,7 +137,7 @@ def test___sample_interval_and_timestamp___create_with_regular_interval___create
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_timestamp_and_time_offset___create_with_regular_interval___creates_waveform_timing_with_sample_interval_timestamp_and_time_offset() -> (
+def test___sample_interval_timestamp_and_time_offset___create_with_regular_interval___creates_timing_with_sample_interval_timestamp_and_time_offset() -> (
     None
 ):
     sample_interval = bt.TimeDelta(1e-3)
@@ -155,7 +153,7 @@ def test___sample_interval_timestamp_and_time_offset___create_with_regular_inter
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_and_time_offset___create_with_regular_interval___creates_waveform_timing_with_sample_interval_and_time_offset() -> (
+def test___sample_interval_and_time_offset___create_with_regular_interval___creates_timing_with_sample_interval_and_time_offset() -> (
     None
 ):
     sample_interval = bt.TimeDelta(1e-3)
@@ -211,7 +209,7 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
         ],
     ],
 )
-def test___monotonic_timestamps___create_with_irregular_interval___creates_waveform_timing_with_timestamps(
+def test___monotonic_timestamps___create_with_irregular_interval___creates_timing_with_timestamps(
     time_offsets: list[bt.TimeDelta],
 ) -> None:
     start_time = bt.DateTime.now(dt.timezone.utc)
@@ -243,7 +241,7 @@ def test___non_monotonic_timestamps___create_with_irregular_interval___raises_va
     assert exc.value.args[0].startswith("The timestamps must be in ascending or descending order.")
 
 
-def test___timestamps_tuple___create_with_irregular_interval___creates_waveform_timing_with_timestamps() -> (
+def test___timestamps_tuple___create_with_irregular_interval___creates_timing_with_timestamps() -> (
     None
 ):
     start_time = bt.DateTime.now(dt.timezone.utc)

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -57,6 +57,69 @@ def test___empty___sample_interval_mode_none() -> None:
 
 
 ###############################################################################
+# construct
+###############################################################################
+def test___no_optional_args___construct___creates_empty_timing() -> None:
+    timing = Timing(SampleIntervalMode.NONE)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert not timing.has_time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___timestamp___construct___creates_timing_with_timestamp() -> None:
+    timestamp = bt.DateTime.now(dt.timezone.utc)
+    timing = Timing(SampleIntervalMode.NONE, timestamp)
+
+    assert_type(timing, Timing[bt.DateTime, dt.timedelta, dt.timedelta])
+    assert timing.timestamp == timestamp
+    assert not timing.has_time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___time_offset___construct___creates_timing_with_time_offset() -> None:
+    time_offset = bt.TimeDelta(1.23)
+    timing = Timing(SampleIntervalMode.NONE, time_offset=time_offset)
+
+    assert_type(timing, Timing[dt.datetime, bt.TimeDelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert timing.time_offset == time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___sample_interval___construct___creates_timing_with_sample_interval() -> None:
+    sample_interval = bt.TimeDelta(1e-3)
+
+    timing = Timing(SampleIntervalMode.REGULAR, sample_interval=sample_interval)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, bt.TimeDelta])
+    assert not timing.has_timestamp
+    assert not timing.has_time_offset
+    assert timing.sample_interval == sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
+
+
+def test___sample_interval_timestamp_and_time_offset___construct___creates_timing_with_sample_interval_timestamp_and_time_offset() -> (
+    None
+):
+    sample_interval = bt.TimeDelta(1e-3)
+    timestamp = bt.DateTime.now(dt.timezone.utc)
+    time_offset = bt.TimeDelta(1.23)
+
+    timing = Timing(SampleIntervalMode.REGULAR, timestamp, time_offset, sample_interval)
+
+    assert_type(timing, Timing[bt.DateTime, bt.TimeDelta, bt.TimeDelta])
+    assert timing.timestamp == timestamp
+    assert timing.time_offset == time_offset
+    assert timing.sample_interval == sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
+
+
+###############################################################################
 # create_with_no_interval
 ###############################################################################
 def test___no_args___create_with_no_interval___creates_empty_timing() -> None:

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -58,7 +58,7 @@ def test___empty___sample_interval_mode_none() -> None:
 ###############################################################################
 # create_with_no_interval
 ###############################################################################
-def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -> None:
+def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
     timing = Timing.create_with_no_interval()
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
@@ -68,7 +68,7 @@ def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___timestamp___create_with_no_interval___creates_waveform_timing_with_timestamp() -> None:
+def test___timestamp___create_with_no_interval___creates_timing_with_timestamp() -> None:
     timestamp = dt.datetime.now(dt.timezone.utc)
     timing = Timing.create_with_no_interval(timestamp)
 
@@ -79,7 +79,7 @@ def test___timestamp___create_with_no_interval___creates_waveform_timing_with_ti
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___timestamp_and_time_offset___create_with_no_interval___creates_waveform_timing_with_timestamp_and_time_offset() -> (
+def test___timestamp_and_time_offset___create_with_no_interval___creates_timing_with_timestamp_and_time_offset() -> (
     None
 ):
     timestamp = dt.datetime.now(dt.timezone.utc)
@@ -93,9 +93,7 @@ def test___timestamp_and_time_offset___create_with_no_interval___creates_wavefor
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___time_offset___create_with_no_interval___creates_waveform_timing_with_time_offset() -> (
-    None
-):
+def test___time_offset___create_with_no_interval___creates_timing_with_time_offset() -> None:
     time_offset = dt.timedelta(seconds=1.23)
     timing = Timing.create_with_no_interval(time_offset=time_offset)
 
@@ -109,7 +107,7 @@ def test___time_offset___create_with_no_interval___creates_waveform_timing_with_
 ###############################################################################
 # create_with_regular_interval
 ###############################################################################
-def test___sample_interval___create_with_regular_interval___creates_waveform_timing_with_sample_interval() -> (
+def test___sample_interval___create_with_regular_interval___creates_timing_with_sample_interval() -> (
     None
 ):
     sample_interval = dt.timedelta(milliseconds=1)
@@ -123,7 +121,7 @@ def test___sample_interval___create_with_regular_interval___creates_waveform_tim
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_and_timestamp___create_with_regular_interval___creates_waveform_timing_with_sample_interval_and_timestamp() -> (
+def test___sample_interval_and_timestamp___create_with_regular_interval___creates_timing_with_sample_interval_and_timestamp() -> (
     None
 ):
     sample_interval = dt.timedelta(milliseconds=1)
@@ -138,7 +136,7 @@ def test___sample_interval_and_timestamp___create_with_regular_interval___create
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_timestamp_and_time_offset___create_with_regular_interval___creates_waveform_timing_with_sample_interval_timestamp_and_time_offset() -> (
+def test___sample_interval_timestamp_and_time_offset___create_with_regular_interval___creates_timing_with_sample_interval_timestamp_and_time_offset() -> (
     None
 ):
     sample_interval = dt.timedelta(milliseconds=1)
@@ -154,7 +152,7 @@ def test___sample_interval_timestamp_and_time_offset___create_with_regular_inter
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_and_time_offset___create_with_regular_interval___creates_waveform_timing_with_sample_interval_and_time_offset() -> (
+def test___sample_interval_and_time_offset___create_with_regular_interval___creates_timing_with_sample_interval_and_time_offset() -> (
     None
 ):
     sample_interval = dt.timedelta(milliseconds=1)
@@ -202,7 +200,7 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
         ],
     ],
 )
-def test___monotonic_timestamps___create_with_irregular_interval___creates_waveform_timing_with_timestamps(
+def test___monotonic_timestamps___create_with_irregular_interval___creates_timing_with_timestamps(
     time_offsets: list[dt.timedelta],
 ) -> None:
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -234,7 +232,7 @@ def test___non_monotonic_timestamps___create_with_irregular_interval___raises_va
     assert exc.value.args[0].startswith("The timestamps must be in ascending or descending order.")
 
 
-def test___timestamps_tuple___create_with_irregular_interval___creates_waveform_timing_with_timestamps() -> (
+def test___timestamps_tuple___create_with_irregular_interval___creates_timing_with_timestamps() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -56,6 +56,69 @@ def test___empty___sample_interval_mode_none() -> None:
 
 
 ###############################################################################
+# construct
+###############################################################################
+def test___no_optional_args___construct___creates_empty_timing() -> None:
+    timing = Timing(SampleIntervalMode.NONE)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert not timing.has_time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___timestamp___construct___creates_timing_with_timestamp() -> None:
+    timestamp = dt.datetime.now(dt.timezone.utc)
+    timing = Timing(SampleIntervalMode.NONE, timestamp)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert timing.timestamp == timestamp
+    assert not timing.has_time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___time_offset___construct___creates_timing_with_time_offset() -> None:
+    time_offset = dt.timedelta(seconds=1.23)
+    timing = Timing(SampleIntervalMode.NONE, time_offset=time_offset)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert timing.time_offset == time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___sample_interval___construct___creates_timing_with_sample_interval() -> None:
+    sample_interval = dt.timedelta(seconds=1e-3)
+
+    timing = Timing(SampleIntervalMode.REGULAR, sample_interval=sample_interval)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert not timing.has_time_offset
+    assert timing.sample_interval == sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
+
+
+def test___sample_interval_timestamp_and_time_offset___construct___creates_timing_with_sample_interval_timestamp_and_time_offset() -> (
+    None
+):
+    sample_interval = dt.timedelta(seconds=1e-3)
+    timestamp = dt.datetime.now(dt.timezone.utc)
+    time_offset = dt.timedelta(seconds=1.23)
+
+    timing = Timing(SampleIntervalMode.REGULAR, timestamp, time_offset, sample_interval)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert timing.timestamp == timestamp
+    assert timing.time_offset == time_offset
+    assert timing.sample_interval == sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
+
+
+###############################################################################
 # create_with_no_interval
 ###############################################################################
 def test___no_args___create_with_no_interval___creates_empty_timing() -> None:

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -59,7 +59,7 @@ def test___empty___sample_interval_mode_none() -> None:
 ###############################################################################
 # create_with_no_interval
 ###############################################################################
-def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -> None:
+def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
     timing = Timing.create_with_no_interval()
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
@@ -69,7 +69,7 @@ def test___no_args___create_with_no_interval___creates_empty_waveform_timing() -
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___timestamp___create_with_no_interval___creates_waveform_timing_with_timestamp() -> None:
+def test___timestamp___create_with_no_interval___creates_timing_with_timestamp() -> None:
     timestamp = ht.datetime.now(dt.timezone.utc)
     timing = Timing.create_with_no_interval(timestamp)
 
@@ -80,7 +80,7 @@ def test___timestamp___create_with_no_interval___creates_waveform_timing_with_ti
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___timestamp_and_time_offset___create_with_no_interval___creates_waveform_timing_with_timestamp_and_time_offset() -> (
+def test___timestamp_and_time_offset___create_with_no_interval___creates_timing_with_timestamp_and_time_offset() -> (
     None
 ):
     timestamp = ht.datetime.now(dt.timezone.utc)
@@ -94,9 +94,7 @@ def test___timestamp_and_time_offset___create_with_no_interval___creates_wavefor
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
-def test___time_offset___create_with_no_interval___creates_waveform_timing_with_time_offset() -> (
-    None
-):
+def test___time_offset___create_with_no_interval___creates_timing_with_time_offset() -> None:
     time_offset = ht.timedelta(seconds=1.23)
     timing = Timing.create_with_no_interval(time_offset=time_offset)
 
@@ -110,7 +108,7 @@ def test___time_offset___create_with_no_interval___creates_waveform_timing_with_
 ###############################################################################
 # create_with_regular_interval
 ###############################################################################
-def test___sample_interval___create_with_regular_interval___creates_waveform_timing_with_sample_interval() -> (
+def test___sample_interval___create_with_regular_interval___creates_timing_with_sample_interval() -> (
     None
 ):
     sample_interval = ht.timedelta(milliseconds=1)
@@ -124,7 +122,7 @@ def test___sample_interval___create_with_regular_interval___creates_waveform_tim
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_and_timestamp___create_with_regular_interval___creates_waveform_timing_with_sample_interval_and_timestamp() -> (
+def test___sample_interval_and_timestamp___create_with_regular_interval___creates_timing_with_sample_interval_and_timestamp() -> (
     None
 ):
     sample_interval = ht.timedelta(milliseconds=1)
@@ -139,7 +137,7 @@ def test___sample_interval_and_timestamp___create_with_regular_interval___create
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_timestamp_and_time_offset___create_with_regular_interval___creates_waveform_timing_with_sample_interval_timestamp_and_time_offset() -> (
+def test___sample_interval_timestamp_and_time_offset___create_with_regular_interval___creates_timing_with_sample_interval_timestamp_and_time_offset() -> (
     None
 ):
     sample_interval = ht.timedelta(milliseconds=1)
@@ -155,7 +153,7 @@ def test___sample_interval_timestamp_and_time_offset___create_with_regular_inter
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
 
 
-def test___sample_interval_and_time_offset___create_with_regular_interval___creates_waveform_timing_with_sample_interval_and_time_offset() -> (
+def test___sample_interval_and_time_offset___create_with_regular_interval___creates_timing_with_sample_interval_and_time_offset() -> (
     None
 ):
     sample_interval = ht.timedelta(milliseconds=1)
@@ -203,7 +201,7 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
         ],
     ],
 )
-def test___monotonic_timestamps___create_with_irregular_interval___creates_waveform_timing_with_timestamps(
+def test___monotonic_timestamps___create_with_irregular_interval___creates_timing_with_timestamps(
     time_offsets: list[ht.timedelta],
 ) -> None:
     start_time = ht.datetime.now(dt.timezone.utc)
@@ -235,7 +233,7 @@ def test___non_monotonic_timestamps___create_with_irregular_interval___raises_va
     assert exc.value.args[0].startswith("The timestamps must be in ascending or descending order.")
 
 
-def test___timestamps_tuple___create_with_irregular_interval___creates_waveform_timing_with_timestamps() -> (
+def test___timestamps_tuple___create_with_irregular_interval___creates_timing_with_timestamps() -> (
     None
 ):
     start_time = ht.datetime.now(dt.timezone.utc)

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -57,6 +57,69 @@ def test___empty___sample_interval_mode_none() -> None:
 
 
 ###############################################################################
+# construct
+###############################################################################
+def test___no_optional_args___construct___creates_empty_timing() -> None:
+    timing = Timing(SampleIntervalMode.NONE)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert not timing.has_time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___timestamp___construct___creates_timing_with_timestamp() -> None:
+    timestamp = ht.datetime.now(dt.timezone.utc)
+    timing = Timing(SampleIntervalMode.NONE, timestamp)
+
+    assert_type(timing, Timing[ht.datetime, dt.timedelta, dt.timedelta])
+    assert timing.timestamp == timestamp
+    assert not timing.has_time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___time_offset___construct___creates_timing_with_time_offset() -> None:
+    time_offset = ht.timedelta(seconds=1.23)
+    timing = Timing(SampleIntervalMode.NONE, time_offset=time_offset)
+
+    assert_type(timing, Timing[dt.datetime, ht.timedelta, dt.timedelta])
+    assert not timing.has_timestamp
+    assert timing.time_offset == time_offset
+    assert not timing.has_sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.NONE
+
+
+def test___sample_interval___construct___creates_timing_with_sample_interval() -> None:
+    sample_interval = ht.timedelta(seconds=1e-3)
+
+    timing = Timing(SampleIntervalMode.REGULAR, sample_interval=sample_interval)
+
+    assert_type(timing, Timing[dt.datetime, dt.timedelta, ht.timedelta])
+    assert not timing.has_timestamp
+    assert not timing.has_time_offset
+    assert timing.sample_interval == sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
+
+
+def test___sample_interval_timestamp_and_time_offset___construct___creates_timing_with_sample_interval_timestamp_and_time_offset() -> (
+    None
+):
+    sample_interval = ht.timedelta(seconds=1e-3)
+    timestamp = ht.datetime.now(dt.timezone.utc)
+    time_offset = ht.timedelta(seconds=1.23)
+
+    timing = Timing(SampleIntervalMode.REGULAR, timestamp, time_offset, sample_interval)
+
+    assert_type(timing, Timing[ht.datetime, ht.timedelta, ht.timedelta])
+    assert timing.timestamp == timestamp
+    assert timing.time_offset == time_offset
+    assert timing.sample_interval == sample_interval
+    assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
+
+
+###############################################################################
 # create_with_no_interval
 ###############################################################################
 def test___no_args___create_with_no_interval___creates_empty_timing() -> None:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add test cases for using the `Timing` constructor directly, with `assert_type` to verify that it infers the correct type parameters.

Rename "waveform_timing" to "timing" in test names. I thought I did this.

### Why should this Pull Request be merged?

@mjohanse-emr was running into type inference problems when using this constructor directly and I realized there were no tests that called it directly.

### What testing has been done?

Ran mypy, pyright, pytest.