### PR TITLE
docs: Document inherited members

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ htmlhelp_basename = f"{project}doc"
 # tell autoapi to doc the public options
 autoapi_options = list(autoapi.extension._DEFAULT_OPTIONS)
 autoapi_options.remove("private-members")  # note: remove this to include "_" members in docs
+autoapi_options.append("inherited-members")
 autoapi_dirs = [root_path / "src" / "nitypes"]
 autoapi_python_class_content = "both"
 autoapi_type = "python"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Tell sphinx-autoapi to document inherited members.

### Why should this Pull Request be merged?

This makes the `NumericWaveform` members show up in the documentation for `AnalogWaveform` and `ComplexWaveform`

### What testing has been done?

Built docs locally and inspected the waveform docs in a web browser.