### PR TITLE
docs: Add docstring for nitypes.__version__

### DIFF
--- a/src/nitypes/__init__.py
+++ b/src/nitypes/__init__.py
@@ -4,3 +4,4 @@ from importlib.metadata import version
 
 
 __version__ = version(__name__)
+"""nitypes version string."""


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add a docstring for `nitypes.__version__`

### Why should this Pull Request be merged?

https://nitypes.readthedocs.io/en/latest/autoapi/nitypes/index.html displays a blank text box for this attribute.

### What testing has been done?

PR build: https://nitypes--117.org.readthedocs.build/en/117/autoapi/nitypes/index.html shows the text.
