### PR TITLE
github: Pin digest for pypa/gh-action-pypi-publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
         path: dist/
     - run: ls -lR
     - name: Upload to ${{ env.environment }}
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         repository-url: ${{ fromJson(env.environment-info)[env.environment].upload-url }} 
   update_version:


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Pin digest for `pypa/gh-action-pypi-publish` action.

### Why should this Pull Request be merged?

The Renovate debug log shows warnings because `release/v1` is not a tag and doesn't match the regex.

```
DEBUG: Dependency pypa/gh-action-pypi-publish has unsupported/unversioned value release/v1 (versioning=regex:^v?(?<major>\d+)(\.(?<minor>\d+)\.(?<patch>\d+))?$)
DEBUG: github/tags.findCommitOfTag: Tag release/v1 not found for pypa/gh-action-pypi-publish
DEBUG: Could not determine new digest for update.
{
  "packageName": "pypa/gh-action-pypi-publish"
  "currentValue": "release/v1"
  "datasource": "github-tags"
  "newValue": "release/v1"
}
```

### What testing has been done?

None