### PR TITLE
Add Timing.has_start_time property.

### DIFF
--- a/src/nitypes/waveform/_timing/_timing.py
+++ b/src/nitypes/waveform/_timing/_timing.py
@@ -196,6 +196,11 @@ class Timing(Generic[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]):
         return value
 
     @property
+    def has_start_time(self) -> bool:
+        """Indicates whether the waveform timing has a start_time."""
+        return self.has_timestamp
+
+    @property
     def start_time(self) -> _TTimestamp_co:
         """The time that the first sample in the waveform was acquired."""
         value = self.timestamp

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -23,7 +23,6 @@ def test___empty___is_timing() -> None:
 
 def test___empty___no_timestamp() -> None:
     assert not Timing.empty.has_timestamp
-    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.timestamp
 
@@ -31,6 +30,7 @@ def test___empty___no_timestamp() -> None:
 
 
 def test___empty___no_start_time() -> None:
+    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.start_time
 
@@ -65,7 +65,6 @@ def test___no_optional_args___construct___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -82,13 +81,19 @@ def test___timestamp___construct___creates_timing_with_timestamp() -> None:
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
+def test___timestamp___construct___has_start_time() -> None:
+    timestamp = bt.DateTime.now(dt.timezone.utc)
+    timing = Timing(SampleIntervalMode.NONE, timestamp)
+
+    assert timing.has_start_time
+
+
 def test___time_offset___construct___creates_timing_with_time_offset() -> None:
     time_offset = bt.TimeDelta(1.23)
     timing = Timing(SampleIntervalMode.NONE, time_offset=time_offset)
 
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -101,7 +106,6 @@ def test___sample_interval___construct___creates_timing_with_sample_interval() -
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, bt.TimeDelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -131,7 +135,6 @@ def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -168,7 +171,6 @@ def test___time_offset___create_with_no_interval___creates_timing_with_time_offs
 
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -186,7 +188,6 @@ def test___sample_interval___create_with_regular_interval___creates_timing_with_
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, bt.TimeDelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -233,7 +234,6 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
 
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, bt.TimeDelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -23,6 +23,7 @@ def test___empty___is_timing() -> None:
 
 def test___empty___no_timestamp() -> None:
     assert not Timing.empty.has_timestamp
+    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.timestamp
 
@@ -64,6 +65,7 @@ def test___no_optional_args___construct___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -86,6 +88,7 @@ def test___time_offset___construct___creates_timing_with_time_offset() -> None:
 
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -98,6 +101,7 @@ def test___sample_interval___construct___creates_timing_with_sample_interval() -
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, bt.TimeDelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -127,6 +131,7 @@ def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -163,6 +168,7 @@ def test___time_offset___create_with_no_interval___creates_timing_with_time_offs
 
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -180,6 +186,7 @@ def test___sample_interval___create_with_regular_interval___creates_timing_with_
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, bt.TimeDelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -226,6 +233,7 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
 
     assert_type(timing, Timing[dt.datetime, bt.TimeDelta, bt.TimeDelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -22,6 +22,7 @@ def test___empty___is_timing() -> None:
 
 def test___empty___no_timestamp() -> None:
     assert not Timing.empty.has_timestamp
+    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.timestamp
 
@@ -63,6 +64,7 @@ def test___no_optional_args___construct___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -85,6 +87,7 @@ def test___time_offset___construct___creates_timing_with_time_offset() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -97,6 +100,7 @@ def test___sample_interval___construct___creates_timing_with_sample_interval() -
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -126,6 +130,7 @@ def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -162,6 +167,7 @@ def test___time_offset___create_with_no_interval___creates_timing_with_time_offs
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -179,6 +185,7 @@ def test___sample_interval___create_with_regular_interval___creates_timing_with_
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -225,6 +232,7 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -22,7 +22,6 @@ def test___empty___is_timing() -> None:
 
 def test___empty___no_timestamp() -> None:
     assert not Timing.empty.has_timestamp
-    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.timestamp
 
@@ -30,6 +29,7 @@ def test___empty___no_timestamp() -> None:
 
 
 def test___empty___no_start_time() -> None:
+    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.start_time
 
@@ -64,7 +64,6 @@ def test___no_optional_args___construct___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -81,13 +80,19 @@ def test___timestamp___construct___creates_timing_with_timestamp() -> None:
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
+def test___timestamp___construct___has_start_time() -> None:
+    timestamp = dt.datetime.now(dt.timezone.utc)
+    timing = Timing(SampleIntervalMode.NONE, timestamp)
+
+    assert timing.has_start_time
+
+
 def test___time_offset___construct___creates_timing_with_time_offset() -> None:
     time_offset = dt.timedelta(seconds=1.23)
     timing = Timing(SampleIntervalMode.NONE, time_offset=time_offset)
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -100,7 +105,6 @@ def test___sample_interval___construct___creates_timing_with_sample_interval() -
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -130,7 +134,6 @@ def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -167,7 +170,6 @@ def test___time_offset___create_with_no_interval___creates_timing_with_time_offs
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -185,7 +187,6 @@ def test___sample_interval___create_with_regular_interval___creates_timing_with_
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -232,7 +233,6 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -23,7 +23,6 @@ def test___empty___is_timing() -> None:
 
 def test___empty___no_timestamp() -> None:
     assert not Timing.empty.has_timestamp
-    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.timestamp
 
@@ -31,6 +30,7 @@ def test___empty___no_timestamp() -> None:
 
 
 def test___empty___no_start_time() -> None:
+    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.start_time
 
@@ -65,7 +65,6 @@ def test___no_optional_args___construct___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -82,13 +81,19 @@ def test___timestamp___construct___creates_timing_with_timestamp() -> None:
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
 
 
+def test___timestamp___construct___has_start_time() -> None:
+    timestamp = ht.datetime.now(dt.timezone.utc)
+    timing = Timing(SampleIntervalMode.NONE, timestamp)
+
+    assert timing.has_start_time
+
+
 def test___time_offset___construct___creates_timing_with_time_offset() -> None:
     time_offset = ht.timedelta(seconds=1.23)
     timing = Timing(SampleIntervalMode.NONE, time_offset=time_offset)
 
     assert_type(timing, Timing[dt.datetime, ht.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -101,7 +106,6 @@ def test___sample_interval___construct___creates_timing_with_sample_interval() -
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, ht.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -131,7 +135,6 @@ def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -168,7 +171,6 @@ def test___time_offset___create_with_no_interval___creates_timing_with_time_offs
 
     assert_type(timing, Timing[dt.datetime, ht.timedelta, dt.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -186,7 +188,6 @@ def test___sample_interval___create_with_regular_interval___creates_timing_with_
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, ht.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -233,7 +234,6 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
 
     assert_type(timing, Timing[dt.datetime, ht.timedelta, ht.timedelta])
     assert not timing.has_timestamp
-    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -23,6 +23,7 @@ def test___empty___is_timing() -> None:
 
 def test___empty___no_timestamp() -> None:
     assert not Timing.empty.has_timestamp
+    assert not Timing.empty.has_start_time
     with pytest.raises(RuntimeError) as exc:
         _ = Timing.empty.timestamp
 
@@ -64,6 +65,7 @@ def test___no_optional_args___construct___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -86,6 +88,7 @@ def test___time_offset___construct___creates_timing_with_time_offset() -> None:
 
     assert_type(timing, Timing[dt.datetime, ht.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -98,6 +101,7 @@ def test___sample_interval___construct___creates_timing_with_sample_interval() -
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, ht.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -127,6 +131,7 @@ def test___no_args___create_with_no_interval___creates_empty_timing() -> None:
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -163,6 +168,7 @@ def test___time_offset___create_with_no_interval___creates_timing_with_time_offs
 
     assert_type(timing, Timing[dt.datetime, ht.timedelta, dt.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert not timing.has_sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.NONE
@@ -180,6 +186,7 @@ def test___sample_interval___create_with_regular_interval___creates_timing_with_
 
     assert_type(timing, Timing[dt.datetime, dt.timedelta, ht.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert not timing.has_time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR
@@ -226,6 +233,7 @@ def test___sample_interval_and_time_offset___create_with_regular_interval___crea
 
     assert_type(timing, Timing[dt.datetime, ht.timedelta, ht.timedelta])
     assert not timing.has_timestamp
+    assert not timing.has_start_time
     assert timing.time_offset == time_offset
     assert timing.sample_interval == sample_interval
     assert timing.sample_interval_mode == SampleIntervalMode.REGULAR


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Provides the `Timing.has_start_time` property as a convenience. Using this property in `nipanel` code will make things easier to read/understand. This property is simply a pass-through of `Timing.has_timestamp`.

### Why should this Pull Request be merged?

The `nitypes` part of [AB#3166841](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3166841)

### What testing has been done?

Unit tests, mypy, styleguide
