### PR TITLE
waveform: Add DigitalWaveform.from_port() and DigitalWaveform.from_ports()

### DIFF
--- a/src/nitypes/waveform/_digital/_port.py
+++ b/src/nitypes/waveform/_digital/_port.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import sys
+from typing import TypeVar, Union
+
+import numpy as np
+import numpy.typing as npt
+
+AnyPort = Union[np.uint8, np.uint16, np.uint32]
+TPort = TypeVar("TPort", bound=AnyPort)
+
+DIGITAL_PORT_DTYPES = (np.uint8, np.uint16, np.uint32)
+
+
+def bit_count(value: int, /) -> int:
+    """Return the number of 1 bits in value.
+
+    >>> bit_count(0xFFFF)
+    16
+    >>> bit_count(0x1084)
+    3
+    """
+    return _bit_count(value)
+
+
+if sys.version_info >= (3, 10):
+
+    def _bit_count(value: int) -> int:
+        return value.bit_count()
+
+else:
+
+    def _bit_count(value: int) -> int:
+        return bin(value).count("1")
+
+
+def bit_mask(n: int, /) -> int:
+    """Return the bit mask with the lower n bits set.
+
+    >>> bit_mask(0)
+    0
+    >>> bit_mask(4)
+    15
+    >>> bit_mask(9)
+    511
+    >>> bit_mask(32)
+    4294967295
+    >>> bit_mask(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: The number of bits must be a non-negative integer.
+    <BLANKLINE>
+    Number of bits: -1
+    """
+    if n < 0:
+        raise ValueError(
+            "The number of bits must be a non-negative integer.\n\n" f"Number of bits: {n}"
+        )
+    return (1 << n) - 1
+
+
+def get_port_dtype(mask: int) -> np.dtype[AnyPort]:
+    """Return the NumPy port dtype for the given mask.
+
+    >>> get_port_dtype(0xF)
+    dtype('uint8')
+    >>> get_port_dtype(0x100)
+    dtype('uint16')
+    >>> get_port_dtype(0xDEADBEEF)
+    dtype('uint32')
+    >>> get_port_dtype(0x1_0000_0000)
+    Traceback (most recent call last):
+    ...
+    ValueError: The mask must be an unsigned 8-, 16-, or 32-bit integer.
+    <BLANKLINE>
+    Mask: 4294967296
+    """
+    if (mask & 0xFF) == mask:
+        return np.dtype(np.uint8)
+    elif (mask & 0xFFFF) == mask:
+        return np.dtype(np.uint16)
+    elif (mask & 0xFFFFFFFF) == mask:
+        return np.dtype(np.uint32)
+    else:
+        raise ValueError(
+            "The mask must be an unsigned 8-, 16-, or 32-bit integer.\n\n" f"Mask: {mask}"
+        )
+
+
+def port_to_line_data(port_data: npt.NDArray[AnyPort], mask: int) -> npt.NDArray[np.uint8]:
+    """Convert a 1D array of port data to a 2D array of line data, using the specified mask.
+
+    >>> port_to_line_data(np.array([0,1,2,3], np.uint8), 0xFF)
+    array([[0, 0, 0, 0, 0, 0, 0, 0],
+           [1, 0, 0, 0, 0, 0, 0, 0],
+           [0, 1, 0, 0, 0, 0, 0, 0],
+           [1, 1, 0, 0, 0, 0, 0, 0]], dtype=uint8)
+    >>> port_to_line_data(np.array([0,1,2,3], np.uint8), 0x3)
+    array([[0, 0],
+           [1, 0],
+           [0, 1],
+           [1, 1]], dtype=uint8)
+    >>> port_to_line_data(np.array([0,1,2,3], np.uint8), 0x2)
+    array([[0],
+           [0],
+           [1],
+           [1]], dtype=uint8)
+    >>> port_to_line_data(np.array([0,1,2,3], np.uint8), 0)
+    array([], shape=(4, 0), dtype=uint8)
+    >>> port_to_line_data(np.array([0x12000000,0xFE000000], np.uint32), 0xFF000000)
+    array([[0, 1, 0, 0, 1, 0, 0, 0],
+           [0, 1, 1, 1, 1, 1, 1, 1]], dtype=uint8)
+    """
+    port_size = port_data.dtype.itemsize * 8
+    line_data = np.unpackbits(port_data.view(np.uint8), bitorder="little")
+    line_data = line_data.reshape(len(port_data), port_size)
+
+    if mask == bit_mask(port_size):
+        return line_data
+    else:
+        return line_data[:, _mask_to_line_indices(mask)]
+
+
+def _mask_to_line_indices(mask: int) -> list[int]:
+    """Return the line indices for the given mask.
+
+    >>> _mask_to_line_indices(0xF)
+    [0, 1, 2, 3]
+    >>> _mask_to_line_indices(0x100)
+    [8]
+    >>> _mask_to_line_indices(0xDEADBEEF)
+    [0, 1, 2, 3, 5, 6, 7, 9, 10, 11, 12, 13, 15, 16, 18, 19, 21, 23, 25, 26, 27, 28, 30, 31]
+    >>> _mask_to_line_indices(-1)
+    Traceback (most recent call last):
+    ...
+    ValueError: The mask must be a non-negative integer.
+    <BLANKLINE>
+    Mask: -1
+    """
+    if mask < 0:
+        raise ValueError("The mask must be a non-negative integer.\n\n" f"Mask: {mask}")
+    line_indices = []
+    line_index = 0
+    while mask != 0:
+        if mask & 1:
+            line_indices.append(line_index)
+        line_index += 1
+        mask >>= 1
+    return line_indices

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -13,7 +13,7 @@ from typing_extensions import Self
 from nitypes._arguments import arg_to_uint, validate_dtype, validate_unsupported_arg
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
 from nitypes._numpy import asarray as _np_asarray
-from nitypes.waveform._digital._port import bit_count, get_port_dtype, port_to_line_data
+from nitypes.waveform._digital._port import bit_mask, get_port_dtype, port_to_line_data
 from nitypes.waveform._digital._state import DigitalState
 from nitypes.waveform._exceptions import (
     capacity_mismatch,
@@ -153,7 +153,6 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        signal_count: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
     ) -> DigitalWaveform[np.uint8]: ...
@@ -170,7 +169,6 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        signal_count: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
     ) -> DigitalWaveform[_TOtherState]: ...
@@ -185,7 +183,6 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        signal_count: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
     ) -> DigitalWaveform[Any]: ...
@@ -199,7 +196,6 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        signal_count: SupportsIndex | None = None,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
     ) -> DigitalWaveform[Any]:
@@ -207,13 +203,18 @@ class DigitalWaveform(Generic[_TState]):
 
         This method allocates a new array in order to convert the port data to line data.
 
+        Each element of the port data array represents a digital sample taken over a port of
+        signals. Each bit in the sample is a signal value, either on or off. The least significant
+        bit of the sample is placed at signal index 0 of the DigitalWaveform.
+
+        If the input array is not a NumPy array, you must specify the mask.
+
         Args:
             array: The port data as a one-dimensional array or a sequence.
-            mask: The bitmask of lines in the port to include in the waveform.
+            mask: A bitmask specifying which lines to include in the waveform.
             dtype: The NumPy data type for the waveform (line) data.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            signal_count: The number of signals in the waveform.
             extended_properties: The extended properties of the waveform.
             timing: The timing information of the waveform.
 
@@ -226,16 +227,16 @@ class DigitalWaveform(Generic[_TState]):
                     "input array", "one-dimensional array or sequence", array.ndim
                 )
             validate_dtype(array.dtype, _DIGITAL_PORT_DTYPES)
-            default_signal_count = array.dtype.itemsize * 8
+            default_mask = bit_mask(array.dtype.itemsize * 8)
         elif isinstance(array, Sequence) or (
             sys.version_info < (3, 10) and isinstance(array, std_array.array)
         ):
             # np.array([0,1]).dtype is np.int64 by default, so the user must specify the port size.
-            if mask is None and signal_count is None:
+            if mask is None:
                 raise ValueError(
-                    "You must specify a mask or signal count when the input array is a sequence."
+                    "You must specify a mask when the input array is not a NumPy array."
                 )
-            default_signal_count = 0
+            default_mask = 0
         else:
             raise invalid_arg_type("input array", "one or two-dimensional array or sequence", array)
 
@@ -243,15 +244,7 @@ class DigitalWaveform(Generic[_TState]):
             dtype = np.uint8
         validate_dtype(dtype, _DIGITAL_STATE_DTYPES)
 
-        if mask is not None:
-            mask = arg_to_uint("mask", mask)
-            signal_count = arg_to_uint("signal count", signal_count, bit_count(mask))
-        else:
-            signal_count = arg_to_uint("signal count", signal_count, default_signal_count)
-            mask = arg_to_uint("mask", mask, (1 << signal_count) - 1)
-
-        if signal_count != bit_count(mask):
-            raise signal_count_mismatch("provided", signal_count, "mask", mask)
+        mask = arg_to_uint("mask", mask, default_mask)
 
         if isinstance(array, np.ndarray):
             port_dtype = array.dtype
@@ -268,10 +261,143 @@ class DigitalWaveform(Generic[_TState]):
             dtype=dtype,
             start_index=start_index,
             sample_count=sample_count,
-            signal_count=signal_count,
             extended_properties=extended_properties,
             timing=timing,
         )
+
+    @overload
+    @classmethod
+    def from_ports(
+        cls,
+        array: npt.NDArray[Any] | Sequence[Any],
+        masks: Sequence[SupportsIndex] | None = ...,
+        dtype: None = ...,
+        *,
+        start_index: SupportsIndex | None = ...,
+        sample_count: SupportsIndex | None = ...,
+        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
+        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+    ) -> Sequence[DigitalWaveform[np.uint8]]: ...
+
+    @overload
+    @classmethod
+    def from_ports(
+        cls,
+        array: npt.NDArray[Any] | Sequence[Any],
+        masks: Sequence[SupportsIndex] | None = ...,
+        dtype: (
+            type[_TOtherState] | np.dtype[_TOtherState]  # pyright: ignore[reportInvalidTypeVarUse]
+        ) = ...,
+        *,
+        start_index: SupportsIndex | None = ...,
+        sample_count: SupportsIndex | None = ...,
+        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
+        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+    ) -> Sequence[DigitalWaveform[_TOtherState]]: ...
+
+    @overload
+    @classmethod
+    def from_ports(
+        cls,
+        array: npt.NDArray[Any] | Sequence[Any],
+        masks: Sequence[SupportsIndex] | None = ...,
+        dtype: npt.DTypeLike = ...,
+        *,
+        start_index: SupportsIndex | None = ...,
+        sample_count: SupportsIndex | None = ...,
+        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
+        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+    ) -> Sequence[DigitalWaveform[Any]]: ...
+
+    @classmethod
+    def from_ports(
+        cls,
+        array: npt.NDArray[Any] | Sequence[Any],
+        masks: Sequence[SupportsIndex] | None = None,
+        dtype: npt.DTypeLike = None,
+        *,
+        start_index: SupportsIndex | None = 0,
+        sample_count: SupportsIndex | None = None,
+        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
+        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
+    ) -> Sequence[DigitalWaveform[Any]]:
+        """Construct a waveform from a two-dimensional array or sequence of port data.
+
+        This method allocates a new array in order to convert the port data to line data.
+
+        Each row of the port data array corresponds to a resulting DigitalWaveform. Each element of
+        the port data array represents a digital sample taken over a port of signals. Each bit in
+        the sample is a signal value, either on or off. The least significant bit of the sample is
+        placed at signal index 0 of the corresponding DigitalWaveform.
+
+        If the input array is not a NumPy array, you must specify the masks.
+
+        Args:
+            array: The port data as a two-dimensional array or a sequence.
+            masks: A sequence of bitmasks specifying which lines from each port to include in the
+                corresponding waveform.
+            dtype: The NumPy data type for the waveform (line) data.
+            start_index: The sample index at which the waveform data begins.
+            sample_count: The number of samples in the waveform.
+            extended_properties: The extended properties of the waveform.
+            timing: The timing information of the waveform.
+
+        Returns:
+            A waveform containing the specified data.
+        """
+        if isinstance(array, np.ndarray):
+            if array.ndim != 2:
+                raise invalid_array_ndim(
+                    "input array", "two-dimensional array or sequence", array.ndim
+                )
+            validate_dtype(array.dtype, _DIGITAL_PORT_DTYPES)
+            default_masks = [bit_mask(array.dtype.itemsize * 8)] * array.shape[0]
+        elif isinstance(array, Sequence) or (
+            sys.version_info < (3, 10) and isinstance(array, std_array.array)
+        ):
+            # np.array([0,1]).dtype is np.int64 by default, so the user must specify the port size.
+            if masks is None:
+                raise ValueError(
+                    "You must specify the masks when the input array is not a NumPy array."
+                )
+            default_masks = []
+        else:
+            raise invalid_arg_type("input array", "one or two-dimensional array or sequence", array)
+
+        if dtype is None:
+            dtype = np.uint8
+        validate_dtype(dtype, _DIGITAL_STATE_DTYPES)
+
+        if not isinstance(masks, (type(None), Sequence)):
+            raise invalid_arg_type("masks", "sequence of ints")
+        if masks is not None:
+            validated_masks = [arg_to_uint("mask", mask) for mask in masks]
+        else:
+            validated_masks = default_masks
+
+        if isinstance(array, np.ndarray):
+            port_dtype = array.dtype
+        else:
+            port_dtype = get_port_dtype(validated_masks)
+
+        port_data = _np_asarray(array, port_dtype)
+        waveforms = []
+        for port_index in range(port_data.shape[0]):
+            line_data = port_to_line_data(port_data[port_index, :], validated_masks[port_index])
+            if line_data.dtype != dtype:
+                line_data = line_data.view(dtype)
+
+            waveforms.append(
+                cls(
+                    data=line_data,
+                    dtype=dtype,
+                    start_index=start_index,
+                    sample_count=sample_count,
+                    extended_properties=extended_properties,
+                    timing=timing,
+                )
+            )
+        return waveforms
 
     __slots__ = [
         "_data",

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -55,6 +55,7 @@ class DigitalWaveform(Generic[_TState]):
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
+        signal_count: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
     ) -> DigitalWaveform[_TOtherState]: ...
@@ -69,6 +70,7 @@ class DigitalWaveform(Generic[_TState]):
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
+        signal_count: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
     ) -> DigitalWaveform[_TOtherState]: ...
@@ -83,6 +85,7 @@ class DigitalWaveform(Generic[_TState]):
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
+        signal_count: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
     ) -> DigitalWaveform[Any]: ...

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -146,7 +146,7 @@ def sample_interval_mode_mismatch() -> TimingMismatchError:
 def signal_count_mismatch(
     arg_description: Literal["input array", "input waveform", "provided"],
     arg_signal_count: int,
-    other_description: Literal["array", "port", "waveform"],
+    other_description: Literal["array", "mask", "port", "waveform"],
     other_signal_count: int,
 ) -> ValueError:
     """Create a ValueError for an mismatched signal count."""
@@ -157,6 +157,7 @@ def signal_count_mismatch(
     }
     other_key = {
         "array": "Array signal count",
+        "mask": "Mask signal count",
         "port": "Port signal count",
         "waveform": "Waveform signal count",
     }

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -217,6 +217,154 @@ def test___ndarray_2d___from_lines___creates_waveform_with_multi_signal() -> Non
 
 
 ###############################################################################
+# from_port
+###############################################################################
+def test___uint8_ndarray___from_port___creates_waveform_with_8_lines() -> None:
+    array = np.array([0, 1, 2, 3, 0xFF, 0x12, 0x34], np.uint8)
+
+    waveform = DigitalWaveform.from_port(array)
+
+    assert waveform.sample_count == 7
+    assert waveform.signal_count == 8
+    assert waveform.data.tolist() == [
+        [0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [0, 1, 0, 0, 1, 0, 0, 0],
+        [0, 0, 1, 0, 1, 1, 0, 0],
+    ]
+
+
+def test___uint16_ndarray___from_port___creates_waveform_with_16_lines() -> None:
+    array = np.array([0, 1, 2, 3, 0xFFFF, 0x1234, 0x5678], np.uint16)
+
+    waveform = DigitalWaveform.from_port(array)
+
+    assert waveform.sample_count == 7
+    assert waveform.signal_count == 16
+    assert waveform.data.tolist() == [
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        [0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0],
+    ]
+
+
+def test___int_list_and_mask___from_port___creates_waveform_with_masked_lines() -> None:
+    array = [0, 1, 2, 3, 0xFFFF, 0x1234, 0x5678]
+
+    waveform = DigitalWaveform.from_port(array, mask=0xFFFF)
+
+    assert waveform.sample_count == 7
+    assert waveform.signal_count == 16
+    assert waveform.data.tolist() == [
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        [0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0],
+    ]
+
+
+def test___int_list_and_signal_count___from_port___creates_waveform_with_signal_count() -> None:
+    array = [0, 1, 2, 3, 0xFFFF, 0x1234, 0x5678]
+
+    waveform = DigitalWaveform.from_port(array, signal_count=16)
+
+    assert waveform.sample_count == 7
+    assert waveform.signal_count == 16
+    assert waveform.data.tolist() == [
+        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+        [0, 0, 1, 0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0],
+        [0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0],
+    ]
+
+
+def test___mask___from_port___creates_waveform_with_masked_lines() -> None:
+    array = np.array([0xFF, 0x12, 0x34], np.uint8)
+
+    waveform_lo = DigitalWaveform.from_port(array, 0x0F)
+    waveform_hi = DigitalWaveform.from_port(array, 0xF0)
+
+    assert waveform_lo.sample_count == 3
+    assert waveform_lo.signal_count == 4
+    assert waveform_lo.data.tolist() == [
+        [1, 1, 1, 1],
+        [0, 1, 0, 0],
+        [0, 0, 1, 0],
+    ]
+    assert waveform_hi.sample_count == 3
+    assert waveform_hi.signal_count == 4
+    assert waveform_hi.data.tolist() == [
+        [1, 1, 1, 1],
+        [1, 0, 0, 0],
+        [1, 1, 0, 0],
+    ]
+
+
+def test___signal_count___from_port___creates_waveform_with_signal_count() -> None:
+    array = np.array([0, 1, 2, 3, 0xFF, 0x12, 0x34], np.uint8)
+
+    waveform = DigitalWaveform.from_port(array, signal_count=5)
+
+    assert waveform.sample_count == 7
+    assert waveform.signal_count == 5
+    assert waveform.data.tolist() == [
+        [0, 0, 0, 0, 0],
+        [1, 0, 0, 0, 0],
+        [0, 1, 0, 0, 0],
+        [1, 1, 0, 0, 0],
+        [1, 1, 1, 1, 1],
+        [0, 1, 0, 0, 1],
+        [0, 0, 1, 0, 1],
+    ]
+
+
+def test___bool_dtype___from_port___creates_waveform_with_bool_dtype() -> None:
+    array = np.array([0, 1, 2, 3, 0xFF, 0x12, 0x34], np.uint8)
+
+    waveform = DigitalWaveform.from_port(array, dtype=np.bool)
+
+    assert waveform.sample_count == 7
+    assert waveform.signal_count == 8
+    assert waveform.data.tolist() == [
+        [False, False, False, False, False, False, False, False],
+        [True, False, False, False, False, False, False, False],
+        [False, True, False, False, False, False, False, False],
+        [True, True, False, False, False, False, False, False],
+        [True, True, True, True, True, True, True, True],
+        [False, True, False, False, True, False, False, False],
+        [False, False, True, False, True, True, False, False],
+    ]
+
+
+def test___array_subset___from_port___creates_waveform_with_array_subset() -> None:
+    array = np.array([0, 1, 2, 3, 0xFF, 0x12, 0x34], np.uint8)
+
+    waveform = DigitalWaveform.from_port(array, start_index=2, sample_count=4)
+
+    assert waveform.sample_count == 4
+    assert waveform.signal_count == 8
+    assert waveform.data.tolist() == [
+        [0, 1, 0, 0, 0, 0, 0, 0],
+        [1, 1, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1],
+        [0, 1, 0, 0, 1, 0, 0, 0],
+    ]
+
+
+###############################################################################
 # data
 ###############################################################################
 def test___uint8_waveform___data___returns_uint8_data() -> None:

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -150,6 +150,73 @@ def test___default_value___create___creates_waveform_with_default_value(
 
 
 ###############################################################################
+# from_lines
+###############################################################################
+def test___uint8_ndarray___from_lines___creates_waveform_with_uint8_dtype() -> None:
+    array = np.array([0, 1, 2, 3], np.uint8)
+
+    waveform = DigitalWaveform.from_lines(array)
+
+    assert_type(waveform, DigitalWaveform[np.uint8])
+    assert isinstance(waveform, DigitalWaveform) and waveform.dtype == np.uint8
+    assert waveform.data.tolist() == [[0], [1], [2], [3]]
+
+
+def test___bool_ndarray___from_lines___creates_waveform_with_bool_dtype() -> None:
+    array = np.array([False, True, False], np.bool)
+
+    waveform = DigitalWaveform.from_lines(array)
+
+    assert_type(waveform, DigitalWaveform[np.bool])
+    assert isinstance(waveform, DigitalWaveform) and waveform.dtype == np.bool
+    assert waveform.data.tolist() == [[False], [True], [False]]
+
+
+def test___int_list_with_int8_dtype___from_lines___creates_waveform_with_int8_dtype() -> None:
+    waveform = DigitalWaveform.from_lines([0, 1, 2, 3], np.int8)
+
+    assert_type(waveform, DigitalWaveform[np.int8])
+    assert isinstance(waveform, DigitalWaveform) and waveform.dtype == np.int8
+    assert waveform.data.tolist() == [[0], [1], [2], [3]]
+
+
+def test___int_list_1d___from_lines___creates_waveform_with_signal_signal() -> None:
+    waveform = DigitalWaveform.from_lines([0, 1, 2, 3])
+
+    assert waveform.sample_count == 4
+    assert waveform.signal_count == 1
+    assert waveform.data.tolist() == [[0], [1], [2], [3]]
+
+
+def test___int_list_2d___from_lines___creates_waveform_with_multi_signal() -> None:
+    waveform = DigitalWaveform.from_lines([[0, 1, 2], [3, 4, 5]])
+
+    assert waveform.sample_count == 2
+    assert waveform.signal_count == 3
+    assert waveform.data.tolist() == [[0, 1, 2], [3, 4, 5]]
+
+
+def test___ndarray_1d___from_lines___creates_waveform_with_one_signal() -> None:
+    array = np.array([0, 1, 2, 3], np.uint8)
+
+    waveform = DigitalWaveform.from_lines(array)
+
+    assert waveform.sample_count == 4
+    assert waveform.signal_count == 1
+    assert waveform.data.tolist() == [[0], [1], [2], [3]]
+
+
+def test___ndarray_2d___from_lines___creates_waveform_with_multi_signal() -> None:
+    array = np.array([[0, 1, 2], [3, 4, 5]], np.uint8)
+
+    waveform = DigitalWaveform.from_lines(array)
+
+    assert waveform.sample_count == 2
+    assert waveform.signal_count == 3
+    assert waveform.data.tolist() == [[0, 1, 2], [3, 4, 5]]
+
+
+###############################################################################
 # data
 ###############################################################################
 def test___uint8_waveform___data___returns_uint8_data() -> None:


### PR DESCRIPTION
- [x]  This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `DigitalWaveform.from_port()` which unpacks a 1D array of port data into a `DigitalWaveform`.

Add `DigitalWaveform.from_ports()` which unpacks a 2D array of port data into a sequence of `DigitalWaveform`s.

### Why should this Pull Request be merged?

Closes AB#3177835

### What testing has been done?

Ran nps lint, mypy, pyright, and pytest