### PR TITLE
waveform: Add DigitalWaveform.test()

### DIFF
--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -197,8 +197,10 @@ from nitypes.waveform._complex import ComplexWaveform
 from nitypes.waveform._digital import (
     DigitalState,
     DigitalWaveform,
+    DigitalWaveformFailure,
     DigitalWaveformSignal,
     DigitalWaveformSignalCollection,
+    DigitalWaveformTestResult,
 )
 from nitypes.waveform._exceptions import TimingMismatchError
 from nitypes.waveform._extended_properties import (
@@ -221,8 +223,10 @@ __all__ = [
     "ComplexWaveform",
     "DigitalState",
     "DigitalWaveform",
+    "DigitalWaveformFailure",
     "DigitalWaveformSignal",
     "DigitalWaveformSignalCollection",
+    "DigitalWaveformTestResult",
     "ExtendedPropertyDictionary",
     "ExtendedPropertyValue",
     "LinearScaleMode",
@@ -245,8 +249,10 @@ AnalogWaveform.__module__ = __name__
 ComplexWaveform.__module__ = __name__
 DigitalState.__module__ = __name__
 DigitalWaveform.__module__ = __name__
+DigitalWaveformFailure.__module__ = __name__
 DigitalWaveformSignal.__module__ = __name__
 DigitalWaveformSignalCollection.__module__ = __name__
+DigitalWaveformTestResult.__module__ = __name__
 ExtendedPropertyDictionary.__module__ = __name__
 # ExtendedPropertyValue is a TypeAlias
 LinearScaleMode.__module__ = __name__

--- a/src/nitypes/waveform/_digital/__init__.py
+++ b/src/nitypes/waveform/_digital/__init__.py
@@ -3,11 +3,17 @@
 from nitypes.waveform._digital._signal import DigitalWaveformSignal
 from nitypes.waveform._digital._signal_collection import DigitalWaveformSignalCollection
 from nitypes.waveform._digital._state import DigitalState
-from nitypes.waveform._digital._waveform import DigitalWaveform
+from nitypes.waveform._digital._waveform import (
+    DigitalWaveform,
+    DigitalWaveformFailure,
+    DigitalWaveformTestResult,
+)
 
 __all__ = [
     "DigitalState",
     "DigitalWaveform",
+    "DigitalWaveformFailure",
     "DigitalWaveformSignal",
     "DigitalWaveformSignalCollection",
+    "DigitalWaveformTestResult",
 ]

--- a/src/nitypes/waveform/_digital/_state.py
+++ b/src/nitypes/waveform/_digital/_state.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from enum import IntEnum
 
+_CHAR_TABLE = "01ZLHXTV"
+
 _STATE_TEST_TABLE = [
     # 0  1  Z  L  H  X  T  V
     [1, 0, 0, 1, 0, 1, 0, 1],  # 0
@@ -41,57 +43,54 @@ class DigitalState(IntEnum):
     """
 
     _value_: int
-    char: str
 
-    def __new__(cls, value: int, pattern: str) -> DigitalState:
-        """Construct a new digital state."""
-        obj = int.__new__(cls, value)
-        obj._value_ = value
-        obj.char = pattern
-        return obj
-
-    FORCE_DOWN = (0, "0")
+    FORCE_DOWN = 0
     """Force logic low. Drive to the low voltage level (VIL)."""
 
-    FORCE_UP = (1, "1")
+    FORCE_UP = 1
     """Force logic high. Drive to the high voltage level (VIH)."""
 
-    FORCE_OFF = (2, "Z")
+    FORCE_OFF = 2
     """Force logic high impedance. Turn the driver off."""
 
-    COMPARE_LOW = (3, "L")
+    COMPARE_LOW = 3
     """Compare logic low (edge). Compare for a voltage level lower than the low voltage threshold
     (VOL)."""
 
-    COMPARE_HIGH = (4, "H")
+    COMPARE_HIGH = 4
     """Compare logic high (edge). Compare for a voltage level higher than the high voltage threshold
     (VOH)."""
 
-    COMPARE_UNKNOWN = (5, "X")
+    COMPARE_UNKNOWN = 5
     """Compare logic unknown. Don't compare."""
 
-    COMPARE_OFF = (6, "T")
+    COMPARE_OFF = 6
     """Compare logic high impedance (edge). Compare for a voltage level between the low voltage
     threshold (VOL) and the high voltage threshold (VOH)."""
 
-    COMPARE_VALID = (7, "V")
+    COMPARE_VALID = 7
     """Compare logic valid level (edge). Compare for a voltage level either lower than the low
     voltage threshold (VOL) or higher than the high voltage threshold (VOH)."""
+
+    @property
+    def char(self) -> str:
+        """The character representing the digital state."""
+        return _CHAR_TABLE[self]
 
     @classmethod
     def from_char(cls, char: str) -> DigitalState:
         """Look up the digital state for the corresponding character."""
-        obj = next((obj for obj in cls if obj.char == char), None)
-        if obj is None:
+        try:
+            return DigitalState(_CHAR_TABLE.index(char))
+        except ValueError:
             raise KeyError(char)
-        return obj
 
     @classmethod
     def to_char(cls, state: DigitalState) -> str:
         """Get a character representing the digital state."""
-        try:
-            return DigitalState(state).char
-        except ValueError:
+        if 0 <= state < len(_CHAR_TABLE):
+            return _CHAR_TABLE[state]
+        else:
             return "?"
 
     @staticmethod

--- a/src/nitypes/waveform/_digital/_state.py
+++ b/src/nitypes/waveform/_digital/_state.py
@@ -2,6 +2,18 @@ from __future__ import annotations
 
 from enum import IntEnum
 
+_STATE_TEST_TABLE = [
+    # 0  1  Z  L  H  X  T  V
+    [1, 0, 0, 1, 0, 1, 0, 1],  # 0
+    [0, 1, 0, 0, 1, 1, 0, 1],  # 1
+    [0, 0, 1, 0, 0, 1, 1, 0],  # Z
+    [1, 0, 0, 1, 0, 1, 0, 0],  # L
+    [0, 1, 0, 0, 1, 1, 0, 0],  # H
+    [1, 1, 1, 1, 1, 1, 1, 1],  # X
+    [0, 0, 1, 0, 0, 1, 1, 0],  # T
+    [1, 1, 0, 0, 0, 1, 0, 1],  # V
+]
+
 
 class DigitalState(IntEnum):
     """An IntEnum of the different digital states that a digital signal can represent.
@@ -13,35 +25,29 @@ class DigitalState(IntEnum):
     >>> DigitalState.FORCE_OFF == 2
     True
 
-    Or you can use its :any:`value` and :any:`pattern` properties:
+    Or you can use its :any:`value` and :any:`char` properties:
 
     >>> DigitalState.FORCE_OFF.value
     2
-    >>> DigitalState.FORCE_OFF.pattern
+    >>> DigitalState.FORCE_OFF.char
     'Z'
 
-    You can also use :any:`from_pattern` to look up the digital state for a given pattern:
+    You can also use :any:`from_char` and :any:`to_char` to convert between states and characters:
 
-    >>> DigitalState.from_pattern("Z")
+    >>> DigitalState.from_char("Z")
     <DigitalState.FORCE_OFF: 2>
+    >>> DigitalState.to_char(2)
+    'Z'
     """
 
     _value_: int
-    pattern: str
+    char: str
 
     def __new__(cls, value: int, pattern: str) -> DigitalState:
         """Construct a new digital state."""
         obj = int.__new__(cls, value)
         obj._value_ = value
-        obj.pattern = pattern
-        return obj
-
-    @classmethod
-    def from_pattern(cls, pattern: str) -> DigitalState:
-        """Look up the digital state for a digital pattern."""
-        obj = next((obj for obj in cls if obj.pattern == pattern), None)
-        if obj is None:
-            raise KeyError(pattern)
+        obj.char = pattern
         return obj
 
     FORCE_DOWN = (0, "0")
@@ -71,3 +77,24 @@ class DigitalState(IntEnum):
     COMPARE_VALID = (7, "V")
     """Compare logic valid level (edge). Compare for a voltage level either lower than the low
     voltage threshold (VOL) or higher than the high voltage threshold (VOH)."""
+
+    @classmethod
+    def from_char(cls, char: str) -> DigitalState:
+        """Look up the digital state for the corresponding character."""
+        obj = next((obj for obj in cls if obj.char == char), None)
+        if obj is None:
+            raise KeyError(char)
+        return obj
+
+    @classmethod
+    def to_char(cls, state: DigitalState) -> str:
+        """Get a character representing the digital state."""
+        try:
+            return DigitalState(state).char
+        except ValueError:
+            return "?"
+
+    @staticmethod
+    def test(state1: DigitalState, state2: DigitalState) -> bool:
+        """Test two digital states and return True if the test failed."""
+        return not _STATE_TEST_TABLE[state1][state2]

--- a/src/nitypes/waveform/_digital/_state.py
+++ b/src/nitypes/waveform/_digital/_state.py
@@ -25,19 +25,19 @@ class DigitalState(IntEnum):
     >>> DigitalState.FORCE_OFF == 2
     True
 
-    Or you can use its :any:`value` and :any:`char` properties:
-
-    >>> DigitalState.FORCE_OFF.value
-    2
-    >>> DigitalState.FORCE_OFF.char
-    'Z'
-
-    You can also use :any:`from_char` and :any:`to_char` to convert between states and characters:
+    Use :any:`from_char` and :any:`to_char` to convert between states and characters:
 
     >>> DigitalState.from_char("Z")
     <DigitalState.FORCE_OFF: 2>
     >>> DigitalState.to_char(2)
     'Z'
+
+    Use :any:`test` to compare actual vs. expected states, returning True on failure.
+
+    >>> DigitalState.test(DigitalState.FORCE_DOWN, DigitalState.COMPARE_LOW)
+    False
+    >>> DigitalState.test(DigitalState.FORCE_UP, DigitalState.COMPARE_LOW)
+    True
     """
 
     _value_: int
@@ -97,4 +97,4 @@ class DigitalState(IntEnum):
     @staticmethod
     def test(state1: DigitalState, state2: DigitalState) -> bool:
         """Test two digital states and return True if the test failed."""
-        return not _STATE_TEST_TABLE[state1][state2]
+        return not _STATE_TEST_TABLE[DigitalState(state1)][DigitalState(state2)]

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import datetime as dt
 import sys
 from collections.abc import Mapping, Sequence
-from typing import Any, Generic, SupportsIndex, overload
+from dataclasses import dataclass
+from typing import Any, Generic, NamedTuple, SupportsIndex, overload
 
 import hightime as ht
 import numpy as np
@@ -41,6 +42,37 @@ from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
 if sys.version_info < (3, 10):
     import array as std_array
+
+
+@dataclass(frozen=True)
+class DigitalWaveformFailure:
+    """A test failure, indicating where the actual waveform did not match the expected waveform."""
+
+    sample_index: int
+    """The sample index into the compared waveform where the test failure occurred."""
+
+    expected_sample_index: int
+    """The sample index into the expected waveform where the test failure occurred."""
+
+    signal_index: int
+    """The signal index where the test failure occurred."""
+
+    actual_state: DigitalState
+    """The state from the compared waveform where the test failure occurred."""
+
+    expected_state: DigitalState
+    """The state from the expected waveform where the test failure occurred."""
+
+
+# This is a NamedTuple so you can unpack it into separate variables.
+class DigitalWaveformTestResult(NamedTuple):
+    """A test result from comparing a digital waveform against an expected digital waveform."""
+
+    success: bool
+    """True if the test is successful, False if the test failed."""
+
+    failures: Sequence[DigitalWaveformFailure]
+    """A collection of test failure information."""
 
 
 class DigitalWaveform(Generic[_TState]):
@@ -968,6 +1000,66 @@ class DigitalWaveform(Generic[_TState]):
             self._data = array
             self._start_index = start_index
             self._sample_count = sample_count
+
+    def test(
+        self,
+        expected_waveform: DigitalWaveform[_TState],
+        *,
+        start_sample: SupportsIndex | None = None,
+        expected_start_sample: SupportsIndex | None = None,
+        sample_count: SupportsIndex | None = None,
+    ) -> DigitalWaveformTestResult:
+        """Test the digital waveform against an expected digital waveform.
+
+        Args:
+            expected_waveform: The expected digital waveform to compare against.
+            start_sample: The beginning sample of :any:`self` to compare.
+            expected_start_sample: The beginning sample of :any:`expected_waveform` to compare.
+            sample_count: The number of samples to compare.
+
+        Returns:
+            The test result.
+        """
+        start_sample = arg_to_uint("start sample", start_sample, 0)
+        expected_start_sample = arg_to_uint("expected start sample", expected_start_sample, 0)
+        sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_sample)
+
+        if self.signal_count != expected_waveform.signal_count:
+            raise signal_count_mismatch(
+                "expected waveform", expected_waveform.signal_count, "waveform", self.signal_count
+            )
+        if start_sample + sample_count > self.sample_count:
+            raise start_index_or_sample_count_too_large(
+                start_sample, sample_count, "number of samples in the waveform", self.sample_count
+            )
+        if expected_start_sample + sample_count > expected_waveform.sample_count:
+            raise start_index_or_sample_count_too_large(
+                expected_start_sample,
+                sample_count,
+                "number of samples in the expected waveform",
+                expected_waveform.sample_count,
+            )
+
+        failures = []
+        for sample_index in range(sample_count):
+            for signal_index in range(self.signal_count):
+                actual_state = DigitalState(self.data[start_sample, signal_index])
+                expected_state = DigitalState(
+                    expected_waveform.data[expected_start_sample, signal_index]
+                )
+                if DigitalState.test(actual_state, expected_state):
+                    failures.append(
+                        DigitalWaveformFailure(
+                            start_sample,
+                            expected_start_sample,
+                            signal_index,
+                            actual_state,
+                            expected_state,
+                        )
+                    )
+            start_sample += 1
+            expected_start_sample += 1
+        return DigitalWaveformTestResult(len(failures) == 0, failures)
 
     def __eq__(self, value: object, /) -> bool:
         """Return self==value."""

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -107,6 +107,7 @@ def start_index_or_sample_count_too_large(
     capacity_description: Literal[
         "capacity",
         "input array length",
+        "number of samples in the expected waveform",
         "number of samples in the spectrum",
         "number of samples in the waveform",
     ],
@@ -116,6 +117,7 @@ def start_index_or_sample_count_too_large(
     capacity_key = {
         "capacity": "Capacity",
         "input array length": "Array length",
+        "number of samples in the expected waveform": "Number of samples",
         "number of samples in the spectrum": "Number of samples",
         "number of samples in the waveform": "Number of samples",
     }
@@ -144,13 +146,14 @@ def sample_interval_mode_mismatch() -> TimingMismatchError:
 
 
 def signal_count_mismatch(
-    arg_description: Literal["input array", "input waveform", "provided"],
+    arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
     arg_signal_count: int,
     other_description: Literal["array", "port", "waveform"],
     other_signal_count: int,
 ) -> ValueError:
     """Create a ValueError for an mismatched signal count."""
     arg_key = {
+        "expected waveform": "Expected waveform signal count",
         "input array": "Input array signal count",
         "input waveform": "Input waveform signal count",
         "provided": "Signal count",

--- a/tests/unit/waveform/test_digital_state.py
+++ b/tests/unit/waveform/test_digital_state.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import pytest
+
+from nitypes.waveform import DigitalState
+
+
+@pytest.mark.parametrize(
+    "state, expected_char",
+    [
+        (DigitalState.FORCE_DOWN, "0"),
+        (DigitalState.COMPARE_HIGH, "H"),
+        (DigitalState.COMPARE_UNKNOWN, "X"),
+    ],
+)
+def test___state___to_char___returns_char(state: DigitalState, expected_char: str) -> None:
+    assert DigitalState.to_char(state) == expected_char
+
+
+@pytest.mark.parametrize("state", [-1, 8, 255])
+def test___invalid_state___to_char___returns_question_mark(state: DigitalState) -> None:
+    assert DigitalState.to_char(state) == "?"
+
+
+@pytest.mark.parametrize(
+    "char, expected_state",
+    [
+        ("0", DigitalState.FORCE_DOWN),
+        ("H", DigitalState.COMPARE_HIGH),
+        ("X", DigitalState.COMPARE_UNKNOWN),
+    ],
+)
+def test___char___from_char___returns_state(char: str, expected_state: DigitalState) -> None:
+    assert DigitalState.from_char(char) == expected_state
+
+
+@pytest.mark.parametrize("char", ["}", "?", "A"])
+def test___invalid_char___from_char___raises_key_error(char: str) -> None:
+    with pytest.raises(KeyError) as exc:
+        _ = DigitalState.from_char(char)
+
+    assert exc.value.args[0] == char
+
+
+@pytest.mark.parametrize(
+    "char1, char2, expected_result",
+    [
+        ("0", "0", False),
+        ("1", "1", False),
+        ("1", "0", True),
+        ("1", "X", False),
+        ("0", "X", False),
+        ("H", "L", True),
+    ],
+)
+def test___states___test___returns_pass_fail(char1: str, char2: str, expected_result: bool) -> None:
+    state1 = DigitalState.from_char(char1)
+    state2 = DigitalState.from_char(char2)
+
+    assert DigitalState.test(state1, state2) == expected_result

--- a/tests/unit/waveform/test_digital_state.py
+++ b/tests/unit/waveform/test_digital_state.py
@@ -46,7 +46,11 @@ def test___invalid_char___from_char___raises_key_error(char: str) -> None:
     "char1, char2, expected_result",
     [
         ("0", "0", False),
+        ("0", "L", False),
+        ("0", "H", True),
         ("1", "1", False),
+        ("1", "H", False),
+        ("1", "L", True),
         ("1", "0", True),
         ("1", "X", False),
         ("0", "X", False),
@@ -58,3 +62,20 @@ def test___states___test___returns_pass_fail(char1: str, char2: str, expected_re
     state2 = DigitalState.from_char(char2)
 
     assert DigitalState.test(state1, state2) == expected_result
+    assert DigitalState.test(state2, state1) == expected_result
+
+
+@pytest.mark.parametrize(
+    "state1, state2",
+    [
+        (DigitalState.FORCE_DOWN, -1),
+        (8, DigitalState.COMPARE_UNKNOWN),
+    ],
+)
+def test___invalid_state___test___raises_value_error(
+    state1: DigitalState, state2: DigitalState
+) -> None:
+    with pytest.raises(ValueError) as exc:
+        _ = DigitalState.test(state1, state2)
+
+    assert "is not a valid DigitalState" in exc.value.args[0]


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add `DigitalWaveform.test()`, which compares the waveform against an expected waveform and returns a test result indicating where each test failure occurred.

Revise `DigitalState` to be more like the .NET `DigitalStateUtility` class.

### Why should this Pull Request be merged?

Closes AB#3177836

### What testing has been done?

Ran nps lint, mypy, pyright, pytest