### PR TITLE
docs: Add DigitalWaveform documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - [Waveforms](#waveforms)
   - [Analog Waveforms](#analog-waveforms)
   - [Complex Waveforms](#complex-waveforms)
+  - [Digital Waveforms](#digital-waveforms)
   - [Frequency Spectrums](#frequency-spectrums)
 - [Complex Numbers](#complex-numbers)
   - [Complex Integers](#complex-integers)
@@ -27,7 +28,7 @@
 
 The `nitypes` Python package defines data types for NI Python APIs:
 
-- Analog and complex waveforms
+- Analog, complex, and digital waveforms
 - Frequency spectrums
 - Complex integers
 - Time conversion
@@ -69,6 +70,14 @@ in the API Reference.
 The `nitypes.waveform.ComplexWaveform` class represents a complex-number signal, such as I/Q data,
 with timing information and extended properties (such as channel name and units). For more details,
 see [Complex
+Waveforms](https://nitypes.readthedocs.io/en/latest/autoapi/nitypes/waveform/index.html#complex-waveforms)
+in the API Reference.
+
+## Digital Waveforms
+
+The `nitypes.waveform.DigitalWaveform` class represents one or more digital signals with timing
+information and extended properties (such as channel name and signal names). For more details, see
+[Digital
 Waveforms](https://nitypes.readthedocs.io/en/latest/autoapi/nitypes/waveform/index.html#complex-waveforms)
 in the API Reference.
 

--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -185,7 +185,7 @@ properties such as channel name and signal names.
 Constructing digital waveforms
 ------------------------------
 
-To construct a digital waveform, use the `:any:`DigitalWaveform` class:
+To construct a digital waveform, use the :any:`DigitalWaveform` class:
 
 >>> DigitalWaveform()
 nitypes.waveform.DigitalWaveform(0, 1)
@@ -197,9 +197,9 @@ When displaying a digital waveform as a string, the first number is the sample c
 number is the signal count.
 
 To construct a digital waveform from a NumPy array of line data, use the
-:any:`DigitalWaveform.from_lines` method. Each array element represents a digital signal value such
-as on or off. The line data should be in a 1D array indexed by ``sample`` or a 2D array indexed by
-``(sample, signal)``. The digital waveform will display the line data as a 2D array.
+:any:`DigitalWaveform.from_lines` method. Each array element represents a digital state, such as 1
+for "on" or 0 for "off". The line data should be in a 1D array indexed by sample or a 2D array
+indexed by (sample, signal). The digital waveform displays the line data as a 2D array.
 
 >>> import numpy as np
 >>> DigitalWaveform.from_lines(np.array([0, 1, 0], np.uint8))
@@ -215,8 +215,9 @@ nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1
 
 To construct a digital waveform from a NumPy array of port data, use the
 :any:`DigitalWaveform.from_port` method. Each element of the port data array represents a digital
-sample taken over a port of signals. Each bit in the sample is a signal value, either on or off. The
-least significant bit of the sample is placed at signal index 0 of the DigitalWaveform.
+sample taken over a port of signals. Each bit in the sample is a signal value, either 1 for "on" or
+0 for "off". The least significant bit of the sample is placed at signal index 0 of the
+DigitalWaveform.
 
 >>> DigitalWaveform.from_port(np.array([0, 1, 2, 3], np.uint8))  # doctest: +NORMALIZE_WHITESPACE
 nitypes.waveform.DigitalWaveform(4, 8, data=array([[0, 0, 0, 0, 0, 0, 0, 0],
@@ -292,8 +293,8 @@ By default, digital waveforms use a NumPy ``dtype`` of :any:`numpy.uint8`, which
 memory for each digital state. 
 
 Using ``np.uint8`` allows the waveform to contain digital states other than "on" or off", such as
-such as :any:`DigitalState.FORCE_OFF` (X) or :any:`DigitalState.COMPARE_HIGH` (H). This capability
-is used for digital pattern applications.
+such as :any:`DigitalState.FORCE_OFF` (``X``) or :any:`DigitalState.COMPARE_HIGH` (``H``). This
+capability is used for digital pattern applications.
 
 You can also construct a digital waveform using a NumPy ``dtype`` of :any:`numpy.bool`. This also
 uses a byte of memory for each digital state, but it restricts the states to "on" and "off".
@@ -302,12 +303,12 @@ Testing digital waveforms
 -------------------------
 
 You can use :any:`DigitalWaveform.test` to compare an acquired waveform against an expected
-waveform. This returns a :any:`DigitalWaveformTestResult` object, which has a Boolean ``successs`
-property and a ``failures`` property that contains a collection of :any:`DigitalWaveformFailure`
-objects, indicating the location of each test failure.
+waveform. This returns a :any:`DigitalWaveformTestResult` object, which has a Boolean ``success``
+property and a ``failures`` property containing a collection of :any:`DigitalWaveformFailure`
+objects, which indicate the location of each test failure.
 
-Here is an example. The expected waveform counts in binary using ``COMPARE_LOW`` and
-``COMPARE_HIGH``, but signal 1 of the actual waveform is stuck high.
+Here is an example. The expected waveform counts in binary using ``COMPARE_LOW`` (``L``) and
+``COMPARE_HIGH`` (``H``), but signal 1 of the actual waveform is stuck high.
 
 >>> actual = DigitalWaveform.from_lines([[0, 1], [1, 1], [0, 1], [1, 1]])
 >>> expected = DigitalWaveform.from_lines([[DigitalState.COMPARE_LOW, DigitalState.COMPARE_LOW],

--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -304,10 +304,31 @@ Testing digital waveforms
 You can use :any:`DigitalWaveform.test` to compare an acquired waveform against an expected
 waveform. This returns a :any:`DigitalWaveformTestResult` object, which has a Boolean ``successs`
 property and a ``failures`` property that contains a collection of :any:`DigitalWaveformFailure`
-objects, indicating the locatio of each test failure.
+objects, indicating the location of each test failure.
 
+Here is an example. The expected waveform counts in binary using ``COMPARE_LOW`` and
+``COMPARE_HIGH``, but signal 1 of the actual waveform is stuck high.
 
+>>> actual = DigitalWaveform.from_lines([[0, 1], [1, 1], [0, 1], [1, 1]])
+>>> expected = DigitalWaveform.from_lines([[DigitalState.COMPARE_LOW, DigitalState.COMPARE_LOW],
+... [DigitalState.COMPARE_HIGH, DigitalState.COMPARE_LOW],
+... [DigitalState.COMPARE_LOW, DigitalState.COMPARE_HIGH],
+... [DigitalState.COMPARE_HIGH, DigitalState.COMPARE_HIGH]])
+>>> result = actual.test(expected)
+>>> result.success
+False
+>>> len(result.failures)
+2
 
+The failures indicate the sample indices into the actual and expected waveforms, the signal index,
+and the digital state from the actual and expected waveforms:
+
+>>> result.failures[0]  # doctest: +NORMALIZE_WHITESPACE
+DigitalWaveformFailure(sample_index=0, expected_sample_index=0, signal_index=1,
+actual_state=<DigitalState.FORCE_UP: 1>, expected_state=<DigitalState.COMPARE_LOW: 3>)
+>>> result.failures[1]  # doctest: +NORMALIZE_WHITESPACE
+DigitalWaveformFailure(sample_index=1, expected_sample_index=1, signal_index=1,
+actual_state=<DigitalState.FORCE_UP: 1>, expected_state=<DigitalState.COMPARE_LOW: 3>)
 
 Timing information
 ------------------

--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -176,6 +176,144 @@ Timing information
 
 Complex waveforms have the same timing information as analog waveforms.
 
+Digital Waveforms
+=================
+
+A digital waveform represents one or more digital signals with timing information and extended
+properties such as channel name and signal names.
+
+Constructing digital waveforms
+------------------------------
+
+To construct a digital waveform, use the `:any:`DigitalWaveform` class:
+
+>>> DigitalWaveform()
+nitypes.waveform.DigitalWaveform(0, 1)
+>>> DigitalWaveform(sample_count=5, signal_count=3)  # doctest: +NORMALIZE_WHITESPACE
+nitypes.waveform.DigitalWaveform(5, 3, data=array([[0, 0, 0], [0, 0, 0], [0, 0, 0], [0, 0, 0],
+[0, 0, 0]], dtype=uint8))
+
+When displaying a digital waveform as a string, the first number is the sample count and the second
+number is the signal count.
+
+To construct a digital waveform from a NumPy array of line data, use the
+:any:`DigitalWaveform.from_lines` method. Each array element represents a digital signal value such
+as on or off. The line data should be in a 1D array indexed by ``sample`` or a 2D array indexed by
+``(sample, signal)``. The digital waveform will display the line data as a 2D array.
+
+>>> import numpy as np
+>>> DigitalWaveform.from_lines(np.array([0, 1, 0], np.uint8))
+nitypes.waveform.DigitalWaveform(3, 1, data=array([[0], [1], [0]], dtype=uint8))
+>>> DigitalWaveform.from_lines(np.array([[0, 0], [1, 0], [0, 1], [1, 1]], np.uint8))
+nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=uint8))
+
+You can also use :any:`DigitalWaveform.from_lines` to construct a digital waveform from a sequence,
+such as a list.
+
+>>> DigitalWaveform.from_lines([[0, 0], [1, 0], [0, 1], [1, 1]])
+nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=uint8))
+
+To construct a digital waveform from a NumPy array of port data, use the
+:any:`DigitalWaveform.from_port` method. Each element of the port data array represents a digital
+sample taken over a port of signals. Each bit in the sample is a signal value, either on or off. The
+least significant bit of the sample is placed at signal index 0 of the DigitalWaveform.
+
+>>> DigitalWaveform.from_port(np.array([0, 1, 2, 3], np.uint8))  # doctest: +NORMALIZE_WHITESPACE
+nitypes.waveform.DigitalWaveform(4, 8, data=array([[0, 0, 0, 0, 0, 0, 0, 0],
+[1, 0, 0, 0, 0, 0, 0, 0], [0, 1, 0, 0, 0, 0, 0, 0], [1, 1, 0, 0, 0, 0, 0, 0]], dtype=uint8))
+
+You can use a mask to specify which lines in the port to include in the waveform.
+
+>>> DigitalWaveform.from_port(np.array([0, 1, 2, 3], np.uint8), 0x3)
+nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=uint8))
+
+You can also use a non-NumPy sequence such as a list, but you must specify a mask so the waveform
+knows how many bits are in each list element.
+
+>>> DigitalWaveform.from_port([0, 1, 2, 3], 0x3)
+nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=uint8))
+
+The 2D version, :any:`DigitalWaveform.from_ports`, constructs a sequence of waveforms, one for each
+row of data in the array or nested sequence.
+
+>>> nested_list = [[0, 1, 2, 3], [3, 0, 3, 0]]
+>>> DigitalWaveform.from_ports(nested_list, [0x3, 0x3])  # doctest: +NORMALIZE_WHITESPACE
+[nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=uint8)),
+ nitypes.waveform.DigitalWaveform(4, 2, data=array([[1, 1], [0, 0], [1, 1], [0, 0]], dtype=uint8))]
+
+Digital signals
+---------------
+
+You can access individual signals using the :any:`DigitalWaveform.signals` property.
+
+>>> wfm = DigitalWaveform.from_port([0, 1, 2, 3], 0x3)
+>>> wfm.signals[0]
+nitypes.waveform.DigitalWaveformSignal(data=array([0, 1, 0, 1], dtype=uint8))
+>>> wfm.signals[1]
+nitypes.waveform.DigitalWaveformSignal(data=array([0, 0, 1, 1], dtype=uint8))
+
+The :any:`DigitalWaveformSignal.data` property returns a view of the data for that signal.
+
+>>> wfm.signals[0].data
+array([0, 1, 0, 1], dtype=uint8)
+
+Digital signal names
+--------------------
+
+The :any:`DigitalWaveformSignal.name` property allows you to get and set the signal names.
+
+>>> wfm.signals[0].name = "port0/line0"
+>>> wfm.signals[1].name = "port0/line1"
+>>> wfm.signals[0].name
+'port0/line0'
+>>> wfm.signals[0]
+nitypes.waveform.DigitalWaveformSignal(name='port0/line0', data=array([0, 1, 0, 1], dtype=uint8))
+
+The signal names are stored in the ``NI_LineNames`` extended property on the digital waveform.
+
+>>> wfm.extended_properties["NI_LineNames"]
+'port0/line0, port0/line1'
+
+When creating a digital waveform, you can directly set the ``NI_LineNames`` extended property.
+
+>>> wfm = DigitalWaveform.from_port([2, 4], 0x7,
+... extended_properties={"NI_LineNames": "Dev1/port1/line4, Dev1/port1/line5, Dev1/port1/line6"})
+>>> wfm.signals[0]
+nitypes.waveform.DigitalWaveformSignal(name='Dev1/port1/line4', data=array([0, 0], dtype=uint8))
+>>> wfm.signals[1]
+nitypes.waveform.DigitalWaveformSignal(name='Dev1/port1/line5', data=array([1, 0], dtype=uint8))
+>>> wfm.signals[2]
+nitypes.waveform.DigitalWaveformSignal(name='Dev1/port1/line6', data=array([0, 1], dtype=uint8))
+
+Digital state types
+-------------------
+
+By default, digital waveforms use a NumPy ``dtype`` of :any:`numpy.uint8`, which uses a byte of
+memory for each digital state. 
+
+Using ``np.uint8`` allows the waveform to contain digital states other than "on" or off", such as
+such as :any:`DigitalState.FORCE_OFF` (X) or :any:`DigitalState.COMPARE_HIGH` (H). This capability
+is used for digital pattern applications.
+
+You can also construct a digital waveform using a NumPy ``dtype`` of :any:`numpy.bool`. This also
+uses a byte of memory for each digital state, but it restricts the states to "on" and "off".
+
+Testing digital waveforms
+-------------------------
+
+You can use :any:`DigitalWaveform.test` to compare an acquired waveform against an expected
+waveform. This returns a :any:`DigitalWaveformTestResult` object, which has a Boolean ``successs`
+property and a ``failures`` property that contains a collection of :any:`DigitalWaveformFailure`
+objects, indicating the locatio of each test failure.
+
+
+
+
+Timing information
+------------------
+
+Digital waveforms have the same timing information as analog waveforms.
+
 Frequency Spectrums
 ===================
 

--- a/src/nitypes/waveform/_digital/_state.py
+++ b/src/nitypes/waveform/_digital/_state.py
@@ -47,31 +47,31 @@ class DigitalState(IntEnum):
     _value_: int
 
     FORCE_DOWN = 0
-    """Force logic low. Drive to the low voltage level (VIL)."""
+    """Force logic low (``0``). Drive to the low voltage level (VIL)."""
 
     FORCE_UP = 1
-    """Force logic high. Drive to the high voltage level (VIH)."""
+    """Force logic high (``1``). Drive to the high voltage level (VIH)."""
 
     FORCE_OFF = 2
-    """Force logic high impedance. Turn the driver off."""
+    """Force logic high impedance (``Z``). Turn the driver off."""
 
     COMPARE_LOW = 3
-    """Compare logic low (edge). Compare for a voltage level lower than the low voltage threshold
+    """Compare logic low (edge) (``L``). Compare for a voltage level lower than the low voltage threshold
     (VOL)."""
 
     COMPARE_HIGH = 4
-    """Compare logic high (edge). Compare for a voltage level higher than the high voltage threshold
+    """Compare logic high (edge) (``H``). Compare for a voltage level higher than the high voltage threshold
     (VOH)."""
 
     COMPARE_UNKNOWN = 5
-    """Compare logic unknown. Don't compare."""
+    """Compare logic unknown (``X``). Don't compare."""
 
     COMPARE_OFF = 6
-    """Compare logic high impedance (edge). Compare for a voltage level between the low voltage
+    """Compare logic high impedance (edge) (``T``). Compare for a voltage level between the low voltage
     threshold (VOL) and the high voltage threshold (VOH)."""
 
     COMPARE_VALID = 7
-    """Compare logic valid level (edge). Compare for a voltage level either lower than the low
+    """Compare logic valid level (edge) (``V``). Compare for a voltage level either lower than the low
     voltage threshold (VOL) or higher than the high voltage threshold (VOH)."""
 
     @property

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -140,6 +140,11 @@ class DigitalWaveform(Generic[_TState]):
     ) -> DigitalWaveform[Any]:
         """Construct a waveform from a one or two-dimensional array or sequence of line data.
 
+        Each element of the line data array represents a digital state, such as 1 for "on" or 0
+        for "off". The line data should be in a 1D array indexed by sample or a 2D array indexed
+        by (sample, signal). The line data may also use digital state values from the
+        :any:`DigitalState` enum.
+
         Args:
             array: The line data as a one or two-dimensional array or a sequence.
             dtype: The NumPy data type for the waveform data.
@@ -238,8 +243,9 @@ class DigitalWaveform(Generic[_TState]):
         This method allocates a new array in order to convert the port data to line data.
 
         Each element of the port data array represents a digital sample taken over a port of
-        signals. Each bit in the sample is a signal value, either on or off. The least significant
-        bit of the sample is placed at signal index 0 of the DigitalWaveform.
+        signals. Each bit in the sample represents a digital state, either 1 for "on" or 0 for 
+        "off". The least significant bit of the sample is placed at signal index 0 of the
+        DigitalWaveform.
 
         If the input array is not a NumPy array, you must specify the mask.
 
@@ -361,8 +367,9 @@ class DigitalWaveform(Generic[_TState]):
 
         Each row of the port data array corresponds to a resulting DigitalWaveform. Each element of
         the port data array represents a digital sample taken over a port of signals. Each bit in
-        the sample is a signal value, either on or off. The least significant bit of the sample is
-        placed at signal index 0 of the corresponding DigitalWaveform.
+        the sample is represents a digital state, either 1 for "on" or 0 for "off". The least 
+        significant bit of the sample is placed at signal index 0 of the corresponding 
+        DigitalWaveform.
 
         If the input array is not a NumPy array, you must specify the masks.
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Add documentation to `DigitalWaveform` to `README.md` and the narrative documentation in `nitypes/waveform/__init__.py`.

### Why should this Pull Request be merged?

Closes AB#3178185

### What testing has been done?

Ran nps lint, mypy, pyright, and pytest.
Ran Sphinx locally and inspected the output.