### PR TITLE
waveform: Use covariance/invariance/contravariance more correctly

### DIFF
--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -29,8 +29,8 @@ sequence, such as a list. In this case, you must specify the NumPy data type.
 >>> AnalogWaveform.from_array_1d([1.0, 2.0, 3.0], np.float64)
 nitypes.waveform.AnalogWaveform(3, raw_data=array([1., 2., 3.]))
 
-The 2D version, :any:`AnalogWaveform.from_array_2d`, constructs a list of waveforms, one for each
-row of data in the array or nested sequence.
+The 2D version, :any:`AnalogWaveform.from_array_2d`, returns multiple waveforms, one for each row of
+data in the array or nested sequence.
 
 >>> nested_list = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
 >>> AnalogWaveform.from_array_2d(nested_list, np.float64)  # doctest: +NORMALIZE_WHITESPACE
@@ -234,8 +234,8 @@ knows how many bits are in each list element.
 >>> DigitalWaveform.from_port([0, 1, 2, 3], 0x3)
 nitypes.waveform.DigitalWaveform(4, 2, data=array([[0, 0], [1, 0], [0, 1], [1, 1]], dtype=uint8))
 
-The 2D version, :any:`DigitalWaveform.from_ports`, constructs a sequence of waveforms, one for each
-row of data in the array or nested sequence.
+The 2D version, :any:`DigitalWaveform.from_ports`, returns multiple waveforms, one for each row of
+data in the array or nested sequence.
 
 >>> nested_list = [[0, 1, 2, 3], [3, 0, 3, 0]]
 >>> DigitalWaveform.from_ports(nested_list, [0x3, 0x3])  # doctest: +NORMALIZE_WHITESPACE

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, SupportsIndex, Union, cast, overload
+from typing import Any, SupportsIndex, Union, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -172,7 +172,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[AnalogWaveform[_TOtherRaw]]: ...
+    ) -> Sequence[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
@@ -187,7 +187,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[AnalogWaveform[_TOtherRaw]]: ...
+    ) -> Sequence[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
@@ -202,7 +202,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[AnalogWaveform[Any]]: ...
+    ) -> Sequence[AnalogWaveform[Any]]: ...
 
     @override
     @classmethod
@@ -217,8 +217,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
         scale_mode: ScaleMode | None = None,
-    ) -> list[AnalogWaveform[Any]]:
-        """Construct a list of analog waveforms from a two-dimensional array or nested sequence.
+    ) -> Sequence[AnalogWaveform[Any]]:
+        """Construct multiple analog waveforms from a two-dimensional array or nested sequence.
 
         Args:
             array: The waveform data as a two-dimensional array or a nested sequence.
@@ -232,25 +232,21 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             scale_mode: The scale mode of the waveform.
 
         Returns:
-            A list containing an analog waveform for each row of the specified data.
+            A sequence containing an analog waveform for each row of the specified data.
 
         When constructing multiple waveforms, the same extended properties, timing
         information, and scale mode are applied to all waveforms. Consider assigning
         these properties after construction.
         """
-        # list[T] is invariant but we are using it in a covariant way here.
-        return cast(
-            list[AnalogWaveform[Any]],
-            super(AnalogWaveform, cls).from_array_2d(
-                array,
-                dtype,
-                copy=copy,
-                start_index=start_index,
-                sample_count=sample_count,
-                extended_properties=extended_properties,
-                timing=timing,
-                scale_mode=scale_mode,
-            ),
+        return super(AnalogWaveform, cls).from_array_2d(
+            array,
+            dtype,
+            copy=copy,
+            start_index=start_index,
+            sample_count=sample_count,
+            extended_properties=extended_properties,
+            timing=timing,
+            scale_mode=scale_mode,
         )
 
     __slots__ = ()

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -148,7 +148,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         Returns:
             An analog waveform containing the specified data.
         """
-        return super(AnalogWaveform, cls).from_array_1d(
+        return super().from_array_1d(
             array,
             dtype,
             copy=copy,
@@ -238,7 +238,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         information, and scale mode are applied to all waveforms. Consider assigning
         these properties after construction.
         """
-        return super(AnalogWaveform, cls).from_array_2d(
+        return super().from_array_2d(
             array,
             dtype,
             copy=copy,

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -13,10 +13,10 @@ from nitypes.waveform._numeric import NumericWaveform, _TOtherScaled
 from nitypes.waveform._scaling import ScaleMode
 from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
-# _TRaw and _TRaw_co specify the type of the raw_data array. AnalogWaveform accepts a narrower set
-# of types than NumericWaveform.
+# _TRaw specifies the type of the raw_data array. AnalogWaveform accepts a narrower set of types
+# than NumericWaveform.
 _TRaw = TypeVar("_TRaw", bound=Union[np.floating, np.integer])
-_TRaw_co = TypeVar("_TRaw_co", bound=Union[np.floating, np.integer], covariant=True)
+_TOtherRaw = TypeVar("_TOtherRaw", bound=Union[np.floating, np.integer])
 
 # Use the C types here because np.isdtype() considers some of them to be distinct types, even when
 # they have the same size (e.g. np.intc vs. np.int_).
@@ -48,7 +48,7 @@ _SCALED_DTYPES = (
 
 
 @final
-class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
+class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
     """An analog waveform, which encapsulates analog data and timing information."""
 
     @override
@@ -77,7 +77,7 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
     @classmethod
     def from_array_1d(
         cls,
-        array: npt.NDArray[_TRaw],
+        array: npt.NDArray[_TOtherRaw],
         dtype: None = ...,
         *,
         copy: bool = ...,
@@ -86,14 +86,14 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> AnalogWaveform[_TRaw]: ...
+    ) -> AnalogWaveform[_TOtherRaw]: ...
 
     @overload
     @classmethod
     def from_array_1d(
         cls,
         array: npt.NDArray[Any] | Sequence[Any],
-        dtype: type[_TRaw] | np.dtype[_TRaw],
+        dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
@@ -101,7 +101,7 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> AnalogWaveform[_TRaw]: ...
+    ) -> AnalogWaveform[_TOtherRaw]: ...
 
     @overload
     @classmethod
@@ -163,7 +163,7 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
     @classmethod
     def from_array_2d(
         cls,
-        array: npt.NDArray[_TRaw],
+        array: npt.NDArray[_TOtherRaw],
         dtype: None = ...,
         *,
         copy: bool = ...,
@@ -172,14 +172,14 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[AnalogWaveform[_TRaw]]: ...
+    ) -> list[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
     def from_array_2d(
         cls,
         array: npt.NDArray[Any] | Sequence[Sequence[Any]],
-        dtype: type[_TRaw] | np.dtype[_TRaw],
+        dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
@@ -187,7 +187,7 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[AnalogWaveform[_TRaw]]: ...
+    ) -> list[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
@@ -255,7 +255,7 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
 
     __slots__ = ()
 
-    # If neither dtype nor raw_data is specified, _TRaw_co defaults to np.float64.
+    # If neither dtype nor raw_data is specified, _TRaw defaults to np.float64.
     @overload
     def __init__(  # noqa: D107 - Missing docstring in __init__ (auto-generated noqa)
         self: AnalogWaveform[np.float64],
@@ -273,9 +273,9 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
 
     @overload
     def __init__(  # noqa: D107 - Missing docstring in __init__ (auto-generated noqa)
-        self: AnalogWaveform[_TRaw],
+        self: AnalogWaveform[_TOtherRaw],
         sample_count: SupportsIndex | None = ...,
-        dtype: type[_TRaw] | np.dtype[_TRaw] = ...,
+        dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw] = ...,
         *,
         raw_data: None = ...,
         start_index: SupportsIndex | None = ...,
@@ -288,11 +288,11 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
 
     @overload
     def __init__(  # noqa: D107 - Missing docstring in __init__ (auto-generated noqa)
-        self: AnalogWaveform[_TRaw],
+        self: AnalogWaveform[_TOtherRaw],
         sample_count: SupportsIndex | None = ...,
         dtype: None = ...,
         *,
-        raw_data: npt.NDArray[_TRaw] = ...,
+        raw_data: npt.NDArray[_TOtherRaw] = ...,
         start_index: SupportsIndex | None = ...,
         capacity: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
@@ -367,6 +367,6 @@ class AnalogWaveform(NumericWaveform[_TRaw_co, np.float64]):
     def _convert_data(
         self,
         dtype: npt.DTypeLike | type[_TOtherScaled] | np.dtype[_TOtherScaled],
-        raw_data: npt.NDArray[_TRaw_co],
+        raw_data: npt.NDArray[_TRaw],
     ) -> npt.NDArray[_TOtherScaled]:
         return raw_data.astype(dtype)

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Any, SupportsIndex, Union, cast, overload
+from typing import Any, SupportsIndex, Union, overload
 
 import numpy as np
 import numpy.typing as npt
@@ -157,7 +157,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[ComplexWaveform[_TOtherRaw]]: ...
+    ) -> Sequence[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
@@ -172,7 +172,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[ComplexWaveform[_TOtherRaw]]: ...
+    ) -> Sequence[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
@@ -187,7 +187,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[ComplexWaveform[Any]]: ...
+    ) -> Sequence[ComplexWaveform[Any]]: ...
 
     @override
     @classmethod
@@ -202,8 +202,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
         scale_mode: ScaleMode | None = None,
-    ) -> list[ComplexWaveform[Any]]:
-        """Construct a list of complex waveforms from a two-dimensional array or nested sequence.
+    ) -> Sequence[ComplexWaveform[Any]]:
+        """Construct multiple complex waveforms from a two-dimensional array or nested sequence.
 
         Args:
             array: The waveform data as a two-dimensional array or a nested sequence.
@@ -217,25 +217,21 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             scale_mode: The scale mode of the waveform.
 
         Returns:
-            A list containing a complex waveform for each row of the specified data.
+            A sequence containing a complex waveform for each row of the specified data.
 
         When constructing multiple waveforms, the same extended properties, timing
         information, and scale mode are applied to all waveforms. Consider assigning
         these properties after construction.
         """
-        # list[T] is invariant but we are using it in a covariant way here.
-        return cast(
-            list[ComplexWaveform[Any]],
-            super(ComplexWaveform, cls).from_array_2d(
-                array,
-                dtype,
-                copy=copy,
-                start_index=start_index,
-                sample_count=sample_count,
-                extended_properties=extended_properties,
-                timing=timing,
-                scale_mode=scale_mode,
-            ),
+        return super(ComplexWaveform, cls).from_array_2d(
+            array,
+            dtype,
+            copy=copy,
+            start_index=start_index,
+            sample_count=sample_count,
+            extended_properties=extended_properties,
+            timing=timing,
+            scale_mode=scale_mode,
         )
 
     __slots__ = ()

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -133,7 +133,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         Returns:
             A complex waveform containing the specified data.
         """
-        return super(ComplexWaveform, cls).from_array_1d(
+        return super().from_array_1d(
             array,
             dtype,
             copy=copy,
@@ -223,7 +223,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         information, and scale mode are applied to all waveforms. Consider assigning
         these properties after construction.
         """
-        return super(ComplexWaveform, cls).from_array_2d(
+        return super().from_array_2d(
             array,
             dtype,
             copy=copy,

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -13,11 +13,11 @@ from nitypes.waveform._numeric import NumericWaveform, _TOtherScaled
 from nitypes.waveform._scaling import ScaleMode
 from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
-# _TRaw and _TRaw_co specify the type of the raw_data array. ComplexWaveform accepts a narrower
-# set of types than NumericWaveform. Note that ComplexInt32Base is an alias for np.void, but other
-# structured data types are rejected at run time.
+# _TRaw specifies the type of the raw_data array. ComplexWaveform accepts a narrower set of types
+# than NumericWaveform. Note that ComplexInt32Base is an alias for np.void, but other structured
+# data types are rejected at run time.
 _TRaw = TypeVar("_TRaw", bound=Union[np.complexfloating, ComplexInt32Base])
-_TRaw_co = TypeVar("_TRaw_co", bound=Union[np.complexfloating, ComplexInt32Base], covariant=True)
+_TOtherRaw = TypeVar("_TOtherRaw", bound=Union[np.complexfloating, ComplexInt32Base])
 
 _RAW_DTYPES = (
     # Complex floating point
@@ -35,7 +35,7 @@ _SCALED_DTYPES = (
 
 
 @final
-class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
+class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
     """A complex waveform, which encapsulates complex data and timing information."""
 
     @override
@@ -62,7 +62,7 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
     @classmethod
     def from_array_1d(
         cls,
-        array: npt.NDArray[_TRaw],
+        array: npt.NDArray[_TOtherRaw],
         dtype: None = ...,
         *,
         copy: bool = ...,
@@ -71,14 +71,14 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> ComplexWaveform[_TRaw]: ...
+    ) -> ComplexWaveform[_TOtherRaw]: ...
 
     @overload
     @classmethod
     def from_array_1d(
         cls,
         array: npt.NDArray[Any] | Sequence[Any],
-        dtype: type[_TRaw] | np.dtype[_TRaw],
+        dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
@@ -86,7 +86,7 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> ComplexWaveform[_TRaw]: ...
+    ) -> ComplexWaveform[_TOtherRaw]: ...
 
     @overload
     @classmethod
@@ -148,7 +148,7 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
     @classmethod
     def from_array_2d(
         cls,
-        array: npt.NDArray[_TRaw],
+        array: npt.NDArray[_TOtherRaw],
         dtype: None = ...,
         *,
         copy: bool = ...,
@@ -157,14 +157,14 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[ComplexWaveform[_TRaw]]: ...
+    ) -> list[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
     def from_array_2d(
         cls,
         array: npt.NDArray[Any] | Sequence[Sequence[Any]],
-        dtype: type[_TRaw] | np.dtype[_TRaw],
+        dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
         start_index: SupportsIndex | None = ...,
@@ -172,7 +172,7 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
         scale_mode: ScaleMode | None = ...,
-    ) -> list[ComplexWaveform[_TRaw]]: ...
+    ) -> list[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
     @classmethod
@@ -240,7 +240,7 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
 
     __slots__ = ()
 
-    # If neither dtype nor raw_data is specified, _TRaw_co defaults to np.complex128.
+    # If neither dtype nor raw_data is specified, _TRaw defaults to np.complex128.
     @overload
     def __init__(  # noqa: D107 - Missing docstring in __init__ (auto-generated noqa)
         self: ComplexWaveform[np.complex128],
@@ -258,9 +258,9 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
 
     @overload
     def __init__(  # noqa: D107 - Missing docstring in __init__ (auto-generated noqa)
-        self: ComplexWaveform[_TRaw],
+        self: ComplexWaveform[_TOtherRaw],
         sample_count: SupportsIndex | None = ...,
-        dtype: type[_TRaw] | np.dtype[_TRaw] = ...,
+        dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw] = ...,
         *,
         raw_data: None = ...,
         start_index: SupportsIndex | None = ...,
@@ -273,11 +273,11 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
 
     @overload
     def __init__(  # noqa: D107 - Missing docstring in __init__ (auto-generated noqa)
-        self: ComplexWaveform[_TRaw],
+        self: ComplexWaveform[_TOtherRaw],
         sample_count: SupportsIndex | None = ...,
         dtype: None = ...,
         *,
-        raw_data: npt.NDArray[_TRaw] = ...,
+        raw_data: npt.NDArray[_TOtherRaw] = ...,
         start_index: SupportsIndex | None = ...,
         capacity: SupportsIndex | None = ...,
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
@@ -352,6 +352,6 @@ class ComplexWaveform(NumericWaveform[_TRaw_co, np.complex128]):
     def _convert_data(
         self,
         dtype: npt.DTypeLike | type[_TOtherScaled] | np.dtype[_TOtherScaled],
-        raw_data: npt.NDArray[_TRaw_co],
+        raw_data: npt.NDArray[_TRaw],
     ) -> npt.NDArray[_TOtherScaled]:
         return convert_complex(dtype, raw_data)

--- a/src/nitypes/waveform/_digital/_port.py
+++ b/src/nitypes/waveform/_digital/_port.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import numpy.typing as npt

--- a/src/nitypes/waveform/_extended_properties.py
+++ b/src/nitypes/waveform/_extended_properties.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import operator
-from collections.abc import Mapping
-from typing import Iterator, MutableMapping, Union
+from collections.abc import Iterator, Mapping, MutableMapping
+from typing import Union
 
 from typing_extensions import TypeAlias
 

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -147,8 +147,8 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
         timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
         scale_mode: ScaleMode | None = None,
-    ) -> list[Self]:
-        """Construct a list of waveforms from a two-dimensional array or nested sequence.
+    ) -> Sequence[Self]:
+        """Construct multiple waveforms from a two-dimensional array or nested sequence.
 
         Args:
             array: The waveform data as a two-dimensional array or a nested sequence.
@@ -162,7 +162,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
             scale_mode: The scale mode of the waveform.
 
         Returns:
-            A list containing a waveform for each row of the specified data.
+            A sequence containing a waveform for each row of the specified data.
 
         When constructing multiple waveforms, the same extended properties, timing
         information, and scale mode are applied to all waveforms. Consider assigning

--- a/tests/unit/bintime/test_datetime.py
+++ b/tests/unit/bintime/test_datetime.py
@@ -424,7 +424,7 @@ _VARIOUS_VALUES = [
 
 
 def test___various_values___hash___returns_probably_unique_int() -> None:
-    hashes = set([hash(x) for x in _VARIOUS_VALUES])
+    hashes = {hash(x) for x in _VARIOUS_VALUES}
     assert len(hashes) == len(_VARIOUS_VALUES)
 
 

--- a/tests/unit/bintime/test_timedelta.py
+++ b/tests/unit/bintime/test_timedelta.py
@@ -4,8 +4,9 @@ import copy
 import datetime as dt
 import pickle
 import random
+from collections.abc import Generator
 from decimal import Decimal
-from typing import Any, Generator
+from typing import Any
 
 import hightime as ht
 import pytest
@@ -1171,7 +1172,7 @@ _VARIOUS_VALUES = [
 
 
 def test___various_values___hash___returns_probably_unique_int() -> None:
-    hashes = set([hash(x) for x in _VARIOUS_VALUES])
+    hashes = {hash(x) for x in _VARIOUS_VALUES}
     assert len(hashes) == len(_VARIOUS_VALUES)
 
 

--- a/tests/unit/complex/test_conversion.py
+++ b/tests/unit/complex/test_conversion.py
@@ -209,4 +209,4 @@ def test___complex64_scalar_to_complex128_scalar___convert_complex___converts_sc
 
     assert_type(value_out, np.ndarray[tuple[()], np.dtype[np.complex128]])
     assert isinstance(value_out, np.complex128)
-    assert value_out == pytest.approx((1.23 + 4.56j))
+    assert value_out == pytest.approx(1.23 + 4.56j)

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -7,7 +7,7 @@ import itertools
 import pickle
 import sys
 import weakref
-from typing import Any, SupportsIndex, Union
+from typing import Any, Sequence, SupportsIndex, Union
 
 import hightime as ht
 import numpy as np
@@ -344,6 +344,7 @@ def test___float64_ndarray___from_array_2d___creates_waveform_with_float64_dtype
 
     waveforms = AnalogWaveform.from_array_2d(data)
 
+    assert_type(waveforms, Sequence[AnalogWaveform[np.float64]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -356,6 +357,7 @@ def test___int32_ndarray___from_array_2d___creates_waveform_with_int32_dtype() -
 
     waveforms = AnalogWaveform.from_array_2d(data)
 
+    assert_type(waveforms, Sequence[AnalogWaveform[np.int32]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -370,6 +372,7 @@ def test___int16_ndarray_with_mismatched_dtype___from_array_2d___creates_wavefor
 
     waveforms = AnalogWaveform.from_array_2d(data, np.int32)
 
+    assert_type(waveforms, Sequence[AnalogWaveform[np.int32]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -384,6 +387,7 @@ def test___int32_array_list_with_dtype___from_array_2d___creates_waveform_with_s
 
     waveforms = AnalogWaveform.from_array_2d(data, np.int32)
 
+    assert_type(waveforms, Sequence[AnalogWaveform[np.int32]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -398,6 +402,7 @@ def test___int_list_list_with_dtype___from_array_2d___creates_waveform_with_spec
 
     waveforms = AnalogWaveform.from_array_2d(data, np.int32)
 
+    assert_type(waveforms, Sequence[AnalogWaveform[np.int32]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i]
@@ -412,6 +417,7 @@ def test___int_list_list_with_dtype_str___from_array_2d___creates_waveform_with_
 
     waveforms = AnalogWaveform.from_array_2d(data, "int32")
 
+    assert_type(waveforms, Sequence[AnalogWaveform[Any]])  # dtype not inferred from string
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i]

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -7,7 +7,8 @@ import itertools
 import pickle
 import sys
 import weakref
-from typing import Any, Sequence, SupportsIndex, Union
+from collections.abc import Sequence
+from typing import Any, SupportsIndex, Union
 
 import hightime as ht
 import numpy as np

--- a/tests/unit/waveform/test_complex_waveform.py
+++ b/tests/unit/waveform/test_complex_waveform.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import copy
 import datetime as dt
 import pickle
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import hightime as ht
 import numpy as np

--- a/tests/unit/waveform/test_complex_waveform.py
+++ b/tests/unit/waveform/test_complex_waveform.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import copy
 import datetime as dt
 import pickle
-from typing import Any
+from typing import Any, Sequence
 
 import hightime as ht
 import numpy as np
@@ -162,6 +162,7 @@ def test___complexint32_ndarray___from_array_2d___creates_waveform_with_complexi
 
     waveforms = ComplexWaveform.from_array_2d(data)
 
+    assert_type(waveforms, Sequence[ComplexWaveform[ComplexInt32Base]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -174,6 +175,7 @@ def test___complex64_ndarray___from_array_2d___creates_waveform_with_complex64_d
 
     waveforms = ComplexWaveform.from_array_2d(data)
 
+    assert_type(waveforms, Sequence[ComplexWaveform[np.complex64]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -186,6 +188,7 @@ def test___complex128_ndarray___from_array_2d___creates_waveform_with_complex128
 
     waveforms = ComplexWaveform.from_array_2d(data)
 
+    assert_type(waveforms, Sequence[ComplexWaveform[np.complex128]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i].tolist()
@@ -200,6 +203,7 @@ def test___complex_list_list_with_dtype___from_array_2d___creates_waveform_with_
 
     waveforms = ComplexWaveform.from_array_2d(data, np.complex64)
 
+    assert_type(waveforms, Sequence[ComplexWaveform[np.complex64]])
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i]
@@ -214,6 +218,7 @@ def test___int_list_list_with_dtype_str___from_array_2d___creates_waveform_with_
 
     waveforms = ComplexWaveform.from_array_2d(data, "complex64")
 
+    assert_type(waveforms, Sequence[ComplexWaveform[Any]])  # dtype not inferred from string
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == data[i]

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -5,7 +5,8 @@ import copy
 import datetime as dt
 import pickle
 import weakref
-from typing import Any, Sequence, Union
+from collections.abc import Sequence
+from typing import Any, Union
 
 import hightime as ht
 import numpy as np

--- a/tests/unit/waveform/test_digital_waveform_signal.py
+++ b/tests/unit/waveform/test_digital_waveform_signal.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import copy
 import pickle
-from typing import Any, Sequence
+from collections.abc import Sequence
+from typing import Any
 
 import numpy as np
 import numpy.typing as npt


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Change the waveform `_TRaw` and `_TScaled` scalar type variables to be invariant, not covariant. Mutable objects should not have covariant type variables. If `list` had a covariant type variable, then a function that takes a `list[Fruit]` would allow you to insert an `Orange` in a `list[Apple]`.

In some cases, covariance seemed to be helping because it forced us to use a separate type variable `_TRaw` in static/class/init methods when the class's generic type variable is `_TRaw_co`. Updating the static/class/init methods to use `_TOtherRaw` allows this to work when the class's generic type variable is `_TRaw`.

Change the return type of `from_array_2d` from `list[Waveform[_TRaw]]` to `Sequence[Waveform[_TRaw]]` so the waveform type is covariant. (The waveform's scalar data type is still invariant.) This eliminates the need to cast `NumericWaveform[T]` to `AnalogWaveform[_TRaw]` when sharing code with the `NumericWaveform` base class.

### Why should this Pull Request be merged?

Closes AB#3121122
Closes #32 

### What testing has been done?

Ran nps lint, mypy, pyright, pytest