### PR TITLE
Create a TypedDict to use as a kwargs parameter in many waveform methods

### DIFF
--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -368,6 +368,7 @@ from nitypes.waveform._extended_properties import (
     ExtendedPropertyValue,
 )
 from nitypes.waveform._numeric import NumericWaveform
+from nitypes.waveform._options import WaveformOptions
 from nitypes.waveform._scaling import (
     NO_SCALING,
     LinearScaleMode,
@@ -400,6 +401,7 @@ __all__ = [
     "Timing",
     "TimingMismatchError",
     "TimingMismatchWarning",
+    "WaveformOptions",
 ]
 __doctest_requires__ = {".": ["numpy>=2.0"]}
 
@@ -426,3 +428,4 @@ Spectrum.__module__ = __name__
 Timing.__module__ = __name__
 TimingMismatchError.__module__ = __name__
 TimingMismatchWarning.__module__ = __name__
+WaveformOptions.__module__ = __name__

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -8,8 +8,8 @@ import numpy.typing as npt
 from typing_extensions import TypeVar, Unpack, final, override
 
 from nitypes._numpy import long as _np_long, ulong as _np_ulong
-from nitypes.waveform._common_config import CommonWaveformConfig
 from nitypes.waveform._numeric import NumericWaveform, _TOtherScaled
+from nitypes.waveform._options import WaveformOptions
 
 # _TRaw specifies the type of the raw_data array. AnalogWaveform accepts a narrower set of types
 # than NumericWaveform.
@@ -79,8 +79,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> AnalogWaveform[_TOtherRaw]: ...
 
     @overload
@@ -91,8 +92,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> AnalogWaveform[_TOtherRaw]: ...
 
     @overload
@@ -103,8 +105,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> AnalogWaveform[Any]: ...
 
     @override
@@ -115,8 +118,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
+        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> AnalogWaveform[Any]:
         """Construct an analog waveform from a one-dimensional array or sequence.
 
@@ -125,6 +129,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
+            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
             kwargs: A typed dictionary of common waveform configuration.
 
@@ -136,6 +141,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype,
             **kwargs,
             copy=copy,
+            start_index=start_index,
             sample_count=sample_count,
         )
 
@@ -147,8 +153,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -159,8 +166,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -171,8 +179,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[AnalogWaveform[Any]]: ...
 
     @override
@@ -183,8 +192,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
+        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[AnalogWaveform[Any]]:
         """Construct multiple analog waveforms from a two-dimensional array or nested sequence.
 
@@ -193,6 +203,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
+            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
             kwargs: A typed dictionary of common waveform configuration.
 
@@ -208,6 +219,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype,
             **kwargs,
             copy=copy,
+            start_index=start_index,
             sample_count=sample_count,
         )
 
@@ -221,7 +233,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         raw_data: None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -231,7 +245,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw] = ...,
         *,
         raw_data: None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -241,7 +257,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         raw_data: npt.NDArray[_TOtherRaw] = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -251,7 +269,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = ...,
         *,
         raw_data: npt.NDArray[Any] | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     def __init__(
@@ -260,12 +280,17 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = None,
         *,
         raw_data: npt.NDArray[Any] | None = None,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = None,
+        capacity: SupportsIndex | None = None,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None:
         """Initialize a new analog waveform.
 
         Args:
+            start_index: The sample index at which the analog waveform data begins.
             sample_count: The number of samples in the analog waveform.
+            capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
+                appending samples to the waveform.
             dtype: The NumPy data type for the analog waveform data. If not specified, the data
                 type defaults to np.float64.
             raw_data: A NumPy ndarray to use for sample storage. The analog waveform takes ownership
@@ -281,6 +306,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype,
             **kwargs,
             raw_data=raw_data,
+            start_index=start_index,
+            capacity=capacity,
         )
 
     @override

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -126,15 +126,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             An analog waveform containing the specified data.
@@ -202,15 +194,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A sequence containing an analog waveform for each row of the specified data.
@@ -287,15 +271,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             raw_data: A NumPy ndarray to use for sample storage. The analog waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             An analog waveform.

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any, SupportsIndex, Union, overload
 
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import TypeVar, final, override
+from typing_extensions import TypeVar, Unpack, final, override
 
 from nitypes._numpy import long as _np_long, ulong as _np_ulong
-from nitypes.waveform._extended_properties import ExtendedPropertyValue
+from nitypes.waveform._common_config import CommonWaveformConfig
 from nitypes.waveform._numeric import NumericWaveform, _TOtherScaled
-from nitypes.waveform._scaling import ScaleMode
-from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
 # _TRaw specifies the type of the raw_data array. AnalogWaveform accepts a narrower set of types
 # than NumericWaveform.
@@ -81,11 +79,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> AnalogWaveform[_TOtherRaw]: ...
 
     @overload
@@ -96,11 +91,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> AnalogWaveform[_TOtherRaw]: ...
 
     @overload
@@ -111,11 +103,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> AnalogWaveform[Any]: ...
 
     @override
@@ -126,11 +115,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
-        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
-        scale_mode: ScaleMode | None = None,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> AnalogWaveform[Any]:
         """Construct an analog waveform from a one-dimensional array or sequence.
 
@@ -139,11 +125,16 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
-            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
-            scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration
+                start_index: The sample index at which the waveform data begins.
+                capacity: The number of samples to allocate. Pre-allocating a larger buffer
+                    optimizes appending samples to the waveform.
+                extended_properties: The extended properties of the waveform.
+                copy_extended_properties: Specifies whether to copy the extended properties or take
+                    ownership.
+                timing: The timing information of the waveform.
+                scale_mode: The scale mode of the waveform.
 
         Returns:
             An analog waveform containing the specified data.
@@ -151,12 +142,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         return super().from_array_1d(
             array,
             dtype,
+            **kwargs,
             copy=copy,
-            start_index=start_index,
             sample_count=sample_count,
-            extended_properties=extended_properties,
-            timing=timing,
-            scale_mode=scale_mode,
         )
 
     @overload
@@ -167,11 +155,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -182,11 +167,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[AnalogWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -197,11 +179,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[AnalogWaveform[Any]]: ...
 
     @override
@@ -212,11 +191,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
-        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
-        scale_mode: ScaleMode | None = None,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[AnalogWaveform[Any]]:
         """Construct multiple analog waveforms from a two-dimensional array or nested sequence.
 
@@ -225,11 +201,16 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
-            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
-            scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration
+                start_index: The sample index at which the waveform data begins.
+                capacity: The number of samples to allocate. Pre-allocating a larger buffer
+                    optimizes appending samples to the waveform.
+                extended_properties: The extended properties of the waveform.
+                copy_extended_properties: Specifies whether to copy the extended properties or take
+                    ownership.
+                timing: The timing information of the waveform.
+                scale_mode: The scale mode of the waveform.
 
         Returns:
             A sequence containing an analog waveform for each row of the specified data.
@@ -241,12 +222,9 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         return super().from_array_2d(
             array,
             dtype,
+            **kwargs,
             copy=copy,
-            start_index=start_index,
             sample_count=sample_count,
-            extended_properties=extended_properties,
-            timing=timing,
-            scale_mode=scale_mode,
         )
 
     __slots__ = ()
@@ -259,12 +237,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         raw_data: None = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     @overload
@@ -274,12 +247,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw] = ...,
         *,
         raw_data: None = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     @overload
@@ -289,12 +257,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: None = ...,
         *,
         raw_data: npt.NDArray[_TOtherRaw] = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     @overload
@@ -304,12 +267,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = ...,
         *,
         raw_data: npt.NDArray[Any] | None = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     def __init__(
@@ -318,12 +276,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         dtype: npt.DTypeLike = None,
         *,
         raw_data: npt.NDArray[Any] | None = None,
-        start_index: SupportsIndex | None = None,
-        capacity: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        copy_extended_properties: bool = True,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
-        scale_mode: ScaleMode | None = None,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None:
         """Initialize a new analog waveform.
 
@@ -334,15 +287,15 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             raw_data: A NumPy ndarray to use for sample storage. The analog waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            start_index: The sample index at which the analog waveform data begins.
-            sample_count: The number of samples in the analog waveform.
-            capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
-                appending samples to the waveform.
-            extended_properties: The extended properties of the analog waveform.
-            copy_extended_properties: Specifies whether to copy the extended properties or take
-                ownership.
-            timing: The timing information of the analog waveform.
-            scale_mode: The scale mode of the analog waveform.
+            kwargs: A typed dictionary of common waveform configuration
+                start_index: The sample index at which the waveform data begins.
+                capacity: The number of samples to allocate. Pre-allocating a larger buffer
+                    optimizes appending samples to the waveform.
+                extended_properties: The extended properties of the waveform.
+                copy_extended_properties: Specifies whether to copy the extended properties or take
+                    ownership.
+                timing: The timing information of the waveform.
+                scale_mode: The scale mode of the waveform.
 
         Returns:
             An analog waveform.
@@ -350,13 +303,8 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
         return super().__init__(
             sample_count,
             dtype,
+            **kwargs,
             raw_data=raw_data,
-            start_index=start_index,
-            capacity=capacity,
-            extended_properties=extended_properties,
-            copy_extended_properties=copy_extended_properties,
-            timing=timing,
-            scale_mode=scale_mode,
         )
 
     @override

--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -131,7 +131,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             copy: Specifies whether to copy the array or save a reference to it.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             An analog waveform containing the specified data.
@@ -205,7 +205,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             copy: Specifies whether to copy the array or save a reference to it.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A sequence containing an analog waveform for each row of the specified data.
@@ -296,7 +296,7 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
             raw_data: A NumPy ndarray to use for sample storage. The analog waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             An analog waveform.

--- a/src/nitypes/waveform/_common_config.py
+++ b/src/nitypes/waveform/_common_config.py
@@ -14,8 +14,22 @@ class CommonWaveformConfig(TypedDict, total=False):
     """Common waveform configuration as a typed dictionary."""
 
     start_index: SupportsIndex | None
+    """The sample index at which the waveform data begins."""
+
     capacity: SupportsIndex | None
+    """The number of samples to allocate.
+    
+    Pre-allocating a larger buffer optimizes appending samples to the waveform.
+    """
+
     extended_properties: Mapping[str, ExtendedPropertyValue] | None
+    """The extended properties of the waveform."""
+
     copy_extended_properties: bool
+    """Specifies whether to copy the extended properties or take ownership."""
+
     timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None
+    """The timing information of the waveform."""
+
     scale_mode: ScaleMode | None
+    """The scale mode of the waveform."""

--- a/src/nitypes/waveform/_common_config.py
+++ b/src/nitypes/waveform/_common_config.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import SupportsIndex
+
+from typing_extensions import TypedDict
+
+from nitypes.waveform._extended_properties import ExtendedPropertyValue
+from nitypes.waveform._scaling import ScaleMode
+from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
+
+
+class CommonWaveformConfig(TypedDict, total=False):
+    """Common waveform configuration as a typed dictionary."""
+
+    start_index: SupportsIndex | None
+    capacity: SupportsIndex | None
+    extended_properties: Mapping[str, ExtendedPropertyValue] | None
+    copy_extended_properties: bool
+    timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None
+    scale_mode: ScaleMode | None

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -111,15 +111,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A complex waveform containing the specified data.
@@ -187,15 +179,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A sequence containing a complex waveform for each row of the specified data.
@@ -272,15 +256,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             raw_data: A NumPy ndarray to use for sample storage. The waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A complex waveform.

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -116,7 +116,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             copy: Specifies whether to copy the array or save a reference to it.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A complex waveform containing the specified data.
@@ -190,7 +190,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             copy: Specifies whether to copy the array or save a reference to it.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A sequence containing a complex waveform for each row of the specified data.
@@ -281,7 +281,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             raw_data: A NumPy ndarray to use for sample storage. The waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A complex waveform.

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -1,17 +1,15 @@
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any, SupportsIndex, Union, overload
 
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import TypeVar, final, override
+from typing_extensions import TypeVar, Unpack, final, override
 
 from nitypes.complex import ComplexInt32Base, ComplexInt32DType, convert_complex
-from nitypes.waveform._extended_properties import ExtendedPropertyValue
+from nitypes.waveform._common_config import CommonWaveformConfig
 from nitypes.waveform._numeric import NumericWaveform, _TOtherScaled
-from nitypes.waveform._scaling import ScaleMode
-from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
 # _TRaw specifies the type of the raw_data array. ComplexWaveform accepts a narrower set of types
 # than NumericWaveform. Note that ComplexInt32Base is an alias for np.void, but other structured
@@ -66,11 +64,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> ComplexWaveform[_TOtherRaw]: ...
 
     @overload
@@ -81,11 +76,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> ComplexWaveform[_TOtherRaw]: ...
 
     @overload
@@ -96,11 +88,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> ComplexWaveform[Any]: ...
 
     @override
@@ -111,11 +100,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
-        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
-        scale_mode: ScaleMode | None = None,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> ComplexWaveform[Any]:
         """Construct a complex waveform from a one-dimensional array or sequence.
 
@@ -124,11 +110,16 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
-            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
-            scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration
+                start_index: The sample index at which the waveform data begins.
+                capacity: The number of samples to allocate. Pre-allocating a larger buffer
+                    optimizes appending samples to the waveform.
+                extended_properties: The extended properties of the waveform.
+                copy_extended_properties: Specifies whether to copy the extended properties or take
+                    ownership.
+                timing: The timing information of the waveform.
+                scale_mode: The scale mode of the waveform.
 
         Returns:
             A complex waveform containing the specified data.
@@ -136,12 +127,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         return super().from_array_1d(
             array,
             dtype,
+            **kwargs,
             copy=copy,
-            start_index=start_index,
             sample_count=sample_count,
-            extended_properties=extended_properties,
-            timing=timing,
-            scale_mode=scale_mode,
         )
 
     @overload
@@ -152,11 +140,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -167,11 +152,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -182,11 +164,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
-        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[ComplexWaveform[Any]]: ...
 
     @override
@@ -197,11 +176,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
-        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
-        scale_mode: ScaleMode | None = None,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> Sequence[ComplexWaveform[Any]]:
         """Construct multiple complex waveforms from a two-dimensional array or nested sequence.
 
@@ -210,11 +186,16 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
-            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
-            scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration
+                start_index: The sample index at which the waveform data begins.
+                capacity: The number of samples to allocate. Pre-allocating a larger buffer
+                    optimizes appending samples to the waveform.
+                extended_properties: The extended properties of the waveform.
+                copy_extended_properties: Specifies whether to copy the extended properties or take
+                    ownership.
+                timing: The timing information of the waveform.
+                scale_mode: The scale mode of the waveform.
 
         Returns:
             A sequence containing a complex waveform for each row of the specified data.
@@ -226,12 +207,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         return super().from_array_2d(
             array,
             dtype,
+            **kwargs,
             copy=copy,
-            start_index=start_index,
             sample_count=sample_count,
-            extended_properties=extended_properties,
-            timing=timing,
-            scale_mode=scale_mode,
         )
 
     __slots__ = ()
@@ -244,12 +222,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         raw_data: None = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     @overload
@@ -259,12 +232,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw] = ...,
         *,
         raw_data: None = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     @overload
@@ -274,12 +242,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         raw_data: npt.NDArray[_TOtherRaw] = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     @overload
@@ -289,12 +252,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = ...,
         *,
         raw_data: npt.NDArray[Any] | None = ...,
-        start_index: SupportsIndex | None = ...,
-        capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
-        scale_mode: ScaleMode | None = ...,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None: ...
 
     def __init__(
@@ -303,12 +261,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = None,
         *,
         raw_data: npt.NDArray[Any] | None = None,
-        start_index: SupportsIndex | None = None,
-        capacity: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        copy_extended_properties: bool = True,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
-        scale_mode: ScaleMode | None = None,
+        **kwargs: Unpack[CommonWaveformConfig],
     ) -> None:
         """Initialize a new complex waveform.
 
@@ -319,15 +272,15 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             raw_data: A NumPy ndarray to use for sample storage. The waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            start_index: The sample index at which the waveform data begins.
-            sample_count: The number of samples in the waveform.
-            capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
-                appending samples to the waveform.
-            extended_properties: The extended properties of the waveform.
-            copy_extended_properties: Specifies whether to copy the extended properties or take
-                ownership.
-            timing: The timing information of the waveform.
-            scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration
+                start_index: The sample index at which the waveform data begins.
+                capacity: The number of samples to allocate. Pre-allocating a larger buffer
+                    optimizes appending samples to the waveform.
+                extended_properties: The extended properties of the waveform.
+                copy_extended_properties: Specifies whether to copy the extended properties or take
+                    ownership.
+                timing: The timing information of the waveform.
+                scale_mode: The scale mode of the waveform.
 
         Returns:
             A complex waveform.
@@ -335,13 +288,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         return super().__init__(
             sample_count,
             dtype,
+            **kwargs,
             raw_data=raw_data,
-            start_index=start_index,
-            capacity=capacity,
-            extended_properties=extended_properties,
-            copy_extended_properties=copy_extended_properties,
-            timing=timing,
-            scale_mode=scale_mode,
         )
 
     @override

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -8,8 +8,8 @@ import numpy.typing as npt
 from typing_extensions import TypeVar, Unpack, final, override
 
 from nitypes.complex import ComplexInt32Base, ComplexInt32DType, convert_complex
-from nitypes.waveform._common_config import CommonWaveformConfig
 from nitypes.waveform._numeric import NumericWaveform, _TOtherScaled
+from nitypes.waveform._options import WaveformOptions
 
 # _TRaw specifies the type of the raw_data array. ComplexWaveform accepts a narrower set of types
 # than NumericWaveform. Note that ComplexInt32Base is an alias for np.void, but other structured
@@ -64,8 +64,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> ComplexWaveform[_TOtherRaw]: ...
 
     @overload
@@ -76,8 +77,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> ComplexWaveform[_TOtherRaw]: ...
 
     @overload
@@ -88,8 +90,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> ComplexWaveform[Any]: ...
 
     @override
@@ -100,8 +103,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
+        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> ComplexWaveform[Any]:
         """Construct a complex waveform from a one-dimensional array or sequence.
 
@@ -110,6 +114,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
+            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
             kwargs: A typed dictionary of common waveform configuration.
 
@@ -121,6 +126,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype,
             **kwargs,
             copy=copy,
+            start_index=start_index,
             sample_count=sample_count,
         )
 
@@ -132,8 +138,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -144,8 +151,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw],
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[ComplexWaveform[_TOtherRaw]]: ...
 
     @overload
@@ -156,8 +164,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = ...,
         *,
         copy: bool = ...,
+        start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[ComplexWaveform[Any]]: ...
 
     @override
@@ -168,8 +177,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = None,
         *,
         copy: bool = True,
+        start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        **kwargs: Unpack[CommonWaveformConfig],
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[ComplexWaveform[Any]]:
         """Construct multiple complex waveforms from a two-dimensional array or nested sequence.
 
@@ -178,6 +188,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype: The NumPy data type for the waveform data. This argument is required
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
+            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
             kwargs: A typed dictionary of common waveform configuration.
 
@@ -193,6 +204,7 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype,
             **kwargs,
             copy=copy,
+            start_index=start_index,
             sample_count=sample_count,
         )
 
@@ -206,7 +218,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         raw_data: None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -216,7 +230,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: type[_TOtherRaw] | np.dtype[_TOtherRaw] = ...,
         *,
         raw_data: None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -226,7 +242,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: None = ...,
         *,
         raw_data: npt.NDArray[_TOtherRaw] = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -236,7 +254,9 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = ...,
         *,
         raw_data: npt.NDArray[Any] | None = ...,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = ...,
+        capacity: SupportsIndex | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     def __init__(
@@ -245,12 +265,17 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
         dtype: npt.DTypeLike = None,
         *,
         raw_data: npt.NDArray[Any] | None = None,
-        **kwargs: Unpack[CommonWaveformConfig],
+        start_index: SupportsIndex | None = None,
+        capacity: SupportsIndex | None = None,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None:
         """Initialize a new complex waveform.
 
         Args:
+            start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
+            capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
+                appending samples to the waveform.
             dtype: The NumPy data type for the waveform data. If not specified, the data
                 type defaults to np.complex128.
             raw_data: A NumPy ndarray to use for sample storage. The waveform takes ownership
@@ -266,6 +291,8 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
             dtype,
             **kwargs,
             raw_data=raw_data,
+            start_index=start_index,
+            capacity=capacity,
         )
 
     @override

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -2,14 +2,14 @@ from __future__ import annotations
 
 import datetime as dt
 import sys
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Generic, SupportsIndex, overload
 
 import hightime as ht
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import Self
+from typing_extensions import Self, Unpack
 
 from nitypes._arguments import arg_to_uint, validate_dtype, validate_unsupported_arg
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
@@ -36,8 +36,8 @@ from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
     LINE_NAMES,
     ExtendedPropertyDictionary,
-    ExtendedPropertyValue,
 )
+from nitypes.waveform._options import WaveformOptions
 from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
 if sys.version_info < (3, 10):
@@ -91,8 +91,7 @@ class DigitalWaveform(Generic[_TState]):
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
         signal_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[_TOtherState]: ...
 
     @overload
@@ -106,8 +105,7 @@ class DigitalWaveform(Generic[_TState]):
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
         signal_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[_TOtherState]: ...
 
     @overload
@@ -121,8 +119,7 @@ class DigitalWaveform(Generic[_TState]):
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
         signal_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[Any]: ...
 
     @classmethod
@@ -135,8 +132,7 @@ class DigitalWaveform(Generic[_TState]):
         start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
         signal_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[Any]:
         """Construct a waveform from a one or two-dimensional array or sequence of line data.
 
@@ -152,8 +148,7 @@ class DigitalWaveform(Generic[_TState]):
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
             signal_count: The number of signals in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A waveform containing the specified data.
@@ -174,12 +169,11 @@ class DigitalWaveform(Generic[_TState]):
             raise invalid_arg_type("input array", "one or two-dimensional array or sequence", array)
 
         return cls(
+            **kwargs,
             data=_np_asarray(array, dtype, copy=copy),
             start_index=start_index,
             sample_count=sample_count,
             signal_count=signal_count,
-            extended_properties=extended_properties,
-            timing=timing,
         )
 
     @overload
@@ -192,8 +186,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[np.uint8]: ...
 
     @overload
@@ -208,8 +201,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[_TOtherState]: ...
 
     @overload
@@ -222,8 +214,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[Any]: ...
 
     @classmethod
@@ -235,8 +226,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
+        **kwargs: Unpack[WaveformOptions],
     ) -> DigitalWaveform[Any]:
         """Construct a waveform from a one-dimensional array or sequence of port data.
 
@@ -255,8 +245,7 @@ class DigitalWaveform(Generic[_TState]):
             dtype: The NumPy data type for the waveform (line) data.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A waveform containing the specified data.
@@ -297,12 +286,11 @@ class DigitalWaveform(Generic[_TState]):
             line_data = line_data.view(dtype)
 
         return cls(
+            **kwargs,
             data=line_data,
             dtype=dtype,
             start_index=start_index,
             sample_count=sample_count,
-            extended_properties=extended_properties,
-            timing=timing,
         )
 
     @overload
@@ -315,8 +303,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[DigitalWaveform[np.uint8]]: ...
 
     @overload
@@ -331,8 +318,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[DigitalWaveform[_TOtherState]]: ...
 
     @overload
@@ -345,8 +331,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = ...,
         sample_count: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[DigitalWaveform[Any]]: ...
 
     @classmethod
@@ -358,8 +343,7 @@ class DigitalWaveform(Generic[_TState]):
         *,
         start_index: SupportsIndex | None = 0,
         sample_count: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
+        **kwargs: Unpack[WaveformOptions],
     ) -> Sequence[DigitalWaveform[Any]]:
         """Construct a waveform from a two-dimensional array or sequence of port data.
 
@@ -380,8 +364,7 @@ class DigitalWaveform(Generic[_TState]):
             dtype: The NumPy data type for the waveform (line) data.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            extended_properties: The extended properties of the waveform.
-            timing: The timing information of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A waveform containing the specified data.
@@ -430,12 +413,11 @@ class DigitalWaveform(Generic[_TState]):
 
             waveforms.append(
                 cls(
+                    **kwargs,
                     data=line_data,
                     dtype=dtype,
                     start_index=start_index,
                     sample_count=sample_count,
-                    extended_properties=extended_properties,
-                    timing=timing,
                 )
             )
         return waveforms
@@ -473,9 +455,7 @@ class DigitalWaveform(Generic[_TState]):
         data: None = ...,
         start_index: SupportsIndex | None = ...,
         capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -489,9 +469,7 @@ class DigitalWaveform(Generic[_TState]):
         data: None = ...,
         start_index: SupportsIndex | None = ...,
         capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -505,9 +483,7 @@ class DigitalWaveform(Generic[_TState]):
         data: npt.NDArray[_TOtherState] = ...,
         start_index: SupportsIndex | None = ...,
         capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     @overload
@@ -521,9 +497,7 @@ class DigitalWaveform(Generic[_TState]):
         data: npt.NDArray[Any] | None = ...,
         start_index: SupportsIndex | None = ...,
         capacity: SupportsIndex | None = ...,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = ...,
-        copy_extended_properties: bool = ...,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = ...,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None: ...
 
     def __init__(
@@ -536,9 +510,7 @@ class DigitalWaveform(Generic[_TState]):
         data: npt.NDArray[Any] | None = None,
         start_index: SupportsIndex | None = None,
         capacity: SupportsIndex | None = None,
-        extended_properties: Mapping[str, ExtendedPropertyValue] | None = None,
-        copy_extended_properties: bool = True,
-        timing: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta] | None = None,
+        **kwargs: Unpack[WaveformOptions],
     ) -> None:
         """Initialize a new digital waveform.
 
@@ -554,14 +526,21 @@ class DigitalWaveform(Generic[_TState]):
             sample_count: The number of samples in the waveform.
             capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
                 appending samples to the waveform.
-            extended_properties: The extended properties of the waveform.
-            copy_extended_properties: Specifies whether to copy the extended properties or take
-                ownership.
-            timing: The timing information of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A digital waveform.
         """
+        # Parse kwargs
+        extended_properties = kwargs.get("extended_properties", None)
+        copy_extended_properties = kwargs.get("copy_extended_properties", True)
+        timing = kwargs.get("timing", None)
+
+        # Scaling is not supported for digital waveforms.
+        scale_mode = kwargs.get("scale_mode", None)
+        if scale_mode:
+            raise AttributeError("You cannot set scale_mode on a digital waveform.")
+
         if data is None:
             self._init_with_new_array(
                 sample_count,

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -148,7 +148,7 @@ class DigitalWaveform(Generic[_TState]):
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
             signal_count: The number of signals in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A waveform containing the specified data.
@@ -245,7 +245,7 @@ class DigitalWaveform(Generic[_TState]):
             dtype: The NumPy data type for the waveform (line) data.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A waveform containing the specified data.
@@ -364,7 +364,7 @@ class DigitalWaveform(Generic[_TState]):
             dtype: The NumPy data type for the waveform (line) data.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A waveform containing the specified data.
@@ -526,7 +526,7 @@ class DigitalWaveform(Generic[_TState]):
             sample_count: The number of samples in the waveform.
             capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
                 appending samples to the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A digital waveform.

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -104,7 +104,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
             copy: Specifies whether to copy the array or save a reference to it.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A waveform containing the specified data.
@@ -149,7 +149,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
             copy: Specifies whether to copy the array or save a reference to it.
             start_index: The sample index at which the waveform data begins.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A sequence containing a waveform for each row of the specified data.
@@ -219,7 +219,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
             raw_data: A NumPy ndarray to use for sample storage. The waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            kwargs: A typed dictionary of common waveform configuration.
+            kwargs: Waveform options saved in a :any:`WaveformOptions` object.
 
         Returns:
             A numeric waveform.

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -102,15 +102,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A waveform containing the specified data.
@@ -152,15 +144,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
                 when array is a sequence.
             copy: Specifies whether to copy the array or save a reference to it.
             sample_count: The number of samples in the waveform.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A sequence containing a waveform for each row of the specified data.
@@ -224,15 +208,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
             raw_data: A NumPy ndarray to use for sample storage. The waveform takes ownership
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
-            kwargs: A typed dictionary of common waveform configuration
-                start_index: The sample index at which the waveform data begins.
-                capacity: The number of samples to allocate. Pre-allocating a larger buffer
-                    optimizes appending samples to the waveform.
-                extended_properties: The extended properties of the waveform.
-                copy_extended_properties: Specifies whether to copy the extended properties or take
-                    ownership.
-                timing: The timing information of the waveform.
-                scale_mode: The scale mode of the waveform.
+            kwargs: A typed dictionary of common waveform configuration.
 
         Returns:
             A numeric waveform.

--- a/src/nitypes/waveform/_options.py
+++ b/src/nitypes/waveform/_options.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import SupportsIndex
 
 from typing_extensions import TypedDict
 
@@ -10,17 +9,8 @@ from nitypes.waveform._scaling import ScaleMode
 from nitypes.waveform._timing import Timing, _AnyDateTime, _AnyTimeDelta
 
 
-class CommonWaveformConfig(TypedDict, total=False):
-    """Common waveform configuration as a typed dictionary."""
-
-    start_index: SupportsIndex | None
-    """The sample index at which the waveform data begins."""
-
-    capacity: SupportsIndex | None
-    """The number of samples to allocate.
-    
-    Pre-allocating a larger buffer optimizes appending samples to the waveform.
-    """
+class WaveformOptions(TypedDict, total=False):
+    """Waveform options as a typed dictionary."""
 
     extended_properties: Mapping[str, ExtendedPropertyValue] | None
     """The extended properties of the waveform."""


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

The waveform classes have a lot of overloads with duplicated keyword-only arguments. This PR tries defining a `TypedDict` for these and using `Unpack` to apply it as the type of `**kwargs`.

### Why should this Pull Request be merged?

Implements [AB#3176395](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3176395)

### What testing has been done?

Unit tests, mypy, styleguide.
