### PR TITLE
Replace waveform error methods with error classes.

### DIFF
--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -376,7 +376,7 @@ from nitypes.waveform._scaling import (
 from nitypes.waveform._spectrum import Spectrum
 from nitypes.waveform._timing import SampleIntervalMode, Timing
 from nitypes.waveform._warnings import ScalingMismatchWarning, TimingMismatchWarning
-from nitypes.waveform.exceptions import TimingMismatchError
+from nitypes.waveform.errors import TimingMismatchError
 
 __all__ = [
     "AnalogWaveform",

--- a/src/nitypes/waveform/__init__.py
+++ b/src/nitypes/waveform/__init__.py
@@ -362,7 +362,6 @@ from nitypes.waveform._digital import (
     DigitalWaveformSignalCollection,
     DigitalWaveformTestResult,
 )
-from nitypes.waveform._exceptions import TimingMismatchError
 from nitypes.waveform._extended_properties import (
     ExtendedPropertyDictionary,
     ExtendedPropertyValue,
@@ -377,6 +376,7 @@ from nitypes.waveform._scaling import (
 from nitypes.waveform._spectrum import Spectrum
 from nitypes.waveform._timing import SampleIntervalMode, Timing
 from nitypes.waveform._warnings import ScalingMismatchWarning, TimingMismatchWarning
+from nitypes.waveform.exceptions import TimingMismatchError
 
 __all__ = [
     "AnalogWaveform",

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -24,13 +24,13 @@ from nitypes.waveform._digital._types import (
     _TState,
 )
 from nitypes.waveform._exceptions import (
-    capacity_mismatch,
-    capacity_too_small,
-    data_type_mismatch,
-    irregular_timestamp_count_mismatch,
-    signal_count_mismatch,
-    start_index_or_sample_count_too_large,
-    start_index_too_large,
+    CapacityMismatchError,
+    CapacityTooSmallError,
+    DatatypeMismatchError,
+    IrregularTimestampCountMismatchError,
+    SignalCountMismatchError,
+    StartIndexOrSampleCountTooLargeError,
+    StartIndexTooLargeError,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -164,7 +164,7 @@ class DigitalWaveform(Generic[_TState]):
                     "input array", "one or two-dimensional array or sequence", array.ndim
                 )
             if dtype is not None and array.dtype != dtype:
-                raise data_type_mismatch("input array", array.dtype, "requested", dtype)
+                raise DatatypeMismatchError("input array", array.dtype, "requested", dtype)
         elif isinstance(array, Sequence) or (
             sys.version_info < (3, 10) and isinstance(array, std_array.array)
         ):
@@ -616,9 +616,9 @@ class DigitalWaveform(Generic[_TState]):
         validate_dtype(dtype, _DIGITAL_STATE_DTYPES)
 
         if start_index > capacity:
-            raise start_index_too_large(start_index, "capacity", capacity)
+            raise StartIndexTooLargeError(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -648,7 +648,7 @@ class DigitalWaveform(Generic[_TState]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise data_type_mismatch("input array", data.dtype, "requested", np.dtype(dtype))
+            raise DatatypeMismatchError("input array", data.dtype, "requested", np.dtype(dtype))
         validate_dtype(dtype, _DIGITAL_STATE_DTYPES)
 
         if data.ndim == 1:
@@ -663,21 +663,21 @@ class DigitalWaveform(Generic[_TState]):
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise capacity_mismatch(capacity, len(data))
+            raise CapacityMismatchError(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise start_index_too_large(start_index, "input array length", capacity)
+            raise StartIndexTooLargeError(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "input array length", len(data)
             )
 
         signal_count = arg_to_uint("signal count", signal_count, data_signal_count)
         if signal_count != data_signal_count:
-            raise signal_count_mismatch("provided", signal_count, "array", data_signal_count)
+            raise SignalCountMismatchError("provided", signal_count, "array", data_signal_count)
 
         self._data = data
         self._data_1d = data_1d
@@ -715,13 +715,13 @@ class DigitalWaveform(Generic[_TState]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise start_index_too_large(
+            raise StartIndexTooLargeError(
                 start_index, "number of samples in the waveform", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "number of samples in the waveform", self.sample_count
             )
 
@@ -756,7 +756,7 @@ class DigitalWaveform(Generic[_TState]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise capacity_too_small(value, min_capacity, "waveform")
+            raise CapacityTooSmallError(value, min_capacity, "waveform")
         if value != len(self._data):
             if self._data_1d is not None:
                 # If _data is a 2D view of a 1D array, resize the base array and recreate the view.
@@ -815,7 +815,7 @@ class DigitalWaveform(Generic[_TState]):
 
     def _validate_timing(self, value: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta]) -> None:
         if value._timestamps is not None and len(value._timestamps) != self._sample_count:
-            raise irregular_timestamp_count_mismatch(
+            raise IrregularTimestampCountMismatchError(
                 len(value._timestamps), "number of samples in the waveform", self._sample_count
             )
 
@@ -890,7 +890,7 @@ class DigitalWaveform(Generic[_TState]):
         timestamps: Sequence[dt.datetime] | Sequence[ht.datetime] | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise data_type_mismatch("input array", array.dtype, "waveform", self.dtype)
+            raise DatatypeMismatchError("input array", array.dtype, "waveform", self.dtype)
 
         if array.ndim == 1:
             array_signal_count = 1
@@ -901,12 +901,12 @@ class DigitalWaveform(Generic[_TState]):
             raise invalid_array_ndim("input array", "one or two-dimensional array", array.ndim)
 
         if array_signal_count != self.signal_count:
-            raise signal_count_mismatch(
+            raise SignalCountMismatchError(
                 "input array", array_signal_count, "waveform", self.signal_count
             )
 
         if timestamps is not None and len(array) != len(timestamps):
-            raise irregular_timestamp_count_mismatch(
+            raise IrregularTimestampCountMismatchError(
                 len(timestamps), "input array length", len(array)
             )
 
@@ -925,7 +925,7 @@ class DigitalWaveform(Generic[_TState]):
     def _append_waveforms(self, waveforms: Sequence[DigitalWaveform[_TState]]) -> None:
         for waveform in waveforms:
             if waveform.dtype != self.dtype:
-                raise data_type_mismatch("input waveform", waveform.dtype, "waveform", self.dtype)
+                raise DatatypeMismatchError("input waveform", waveform.dtype, "waveform", self.dtype)
 
         new_timing = self._timing
         for waveform in waveforms:
@@ -977,7 +977,7 @@ class DigitalWaveform(Generic[_TState]):
         signal_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise data_type_mismatch("input array", array.dtype, "waveform", self.dtype)
+            raise DatatypeMismatchError("input array", array.dtype, "waveform", self.dtype)
 
         if array.ndim == 1:
             array_signal_count = 1
@@ -988,7 +988,7 @@ class DigitalWaveform(Generic[_TState]):
             raise invalid_array_ndim("input array", "one or two-dimensional array", array.ndim)
 
         if self._timing._timestamps is not None and len(array) != len(self._timing._timestamps):
-            raise irregular_timestamp_count_mismatch(
+            raise IrregularTimestampCountMismatchError(
                 len(self._timing._timestamps), "input array length", len(array), reversed=True
             )
 
@@ -997,7 +997,7 @@ class DigitalWaveform(Generic[_TState]):
         signal_count = arg_to_uint("signal count", signal_count, array_signal_count)
 
         if signal_count != array_signal_count:
-            raise signal_count_mismatch("input array", signal_count, "waveform", array_signal_count)
+            raise SignalCountMismatchError("input array", signal_count, "waveform", array_signal_count)
 
         if copy:
             if sample_count > len(self._data):
@@ -1034,15 +1034,15 @@ class DigitalWaveform(Generic[_TState]):
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_sample)
 
         if self.signal_count != expected_waveform.signal_count:
-            raise signal_count_mismatch(
+            raise SignalCountMismatchError(
                 "expected waveform", expected_waveform.signal_count, "waveform", self.signal_count
             )
         if start_sample + sample_count > self.sample_count:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_sample, sample_count, "number of samples in the waveform", self.sample_count
             )
         if expected_start_sample + sample_count > expected_waveform.sample_count:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 expected_start_sample,
                 sample_count,
                 "number of samples in the expected waveform",

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -24,13 +24,13 @@ from nitypes.waveform._digital._types import (
     _TState,
 )
 from nitypes.waveform._exceptions import (
-    raise_capacity_mismatch_error,
-    raise_capacity_too_small_error,
-    raise_datatype_mismatch_error,
-    raise_irregular_timestamp_count_mismatch_error,
-    raise_signal_count_mismatch_error,
-    raise_start_index_or_sample_count_too_large_error,
-    raise_start_index_too_large_error,
+    create_capacity_mismatch_error,
+    create_capacity_too_small_error,
+    create_datatype_mismatch_error,
+    create_irregular_timestamp_count_mismatch_error,
+    create_signal_count_mismatch_error,
+    create_start_index_or_sample_count_too_large_error,
+    create_start_index_too_large_error,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -164,7 +164,7 @@ class DigitalWaveform(Generic[_TState]):
                     "input array", "one or two-dimensional array or sequence", array.ndim
                 )
             if dtype is not None and array.dtype != dtype:
-                raise_datatype_mismatch_error("input array", array.dtype, "requested", dtype)
+                raise create_datatype_mismatch_error("input array", array.dtype, "requested", dtype)
         elif isinstance(array, Sequence) or (
             sys.version_info < (3, 10) and isinstance(array, std_array.array)
         ):
@@ -616,9 +616,9 @@ class DigitalWaveform(Generic[_TState]):
         validate_dtype(dtype, _DIGITAL_STATE_DTYPES)
 
         if start_index > capacity:
-            raise_start_index_too_large_error(start_index, "capacity", capacity)
+            raise create_start_index_too_large_error(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -648,7 +648,9 @@ class DigitalWaveform(Generic[_TState]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise_datatype_mismatch_error("input array", data.dtype, "requested", np.dtype(dtype))
+            raise create_datatype_mismatch_error(
+                "input array", data.dtype, "requested", np.dtype(dtype)
+            )
         validate_dtype(dtype, _DIGITAL_STATE_DTYPES)
 
         if data.ndim == 1:
@@ -663,21 +665,23 @@ class DigitalWaveform(Generic[_TState]):
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise_capacity_mismatch_error(capacity, len(data))
+            raise create_capacity_mismatch_error(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise_start_index_too_large_error(start_index, "input array length", capacity)
+            raise create_start_index_too_large_error(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "input array length", len(data)
             )
 
         signal_count = arg_to_uint("signal count", signal_count, data_signal_count)
         if signal_count != data_signal_count:
-            raise_signal_count_mismatch_error("provided", signal_count, "array", data_signal_count)
+            raise create_signal_count_mismatch_error(
+                "provided", signal_count, "array", data_signal_count
+            )
 
         self._data = data
         self._data_1d = data_1d
@@ -715,13 +719,13 @@ class DigitalWaveform(Generic[_TState]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise_start_index_too_large_error(
+            raise create_start_index_too_large_error(
                 start_index, "number of samples in the waveform", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "number of samples in the waveform", self.sample_count
             )
 
@@ -756,7 +760,7 @@ class DigitalWaveform(Generic[_TState]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise_capacity_too_small_error(value, min_capacity, "waveform")
+            raise create_capacity_too_small_error(value, min_capacity, "waveform")
         if value != len(self._data):
             if self._data_1d is not None:
                 # If _data is a 2D view of a 1D array, resize the base array and recreate the view.
@@ -815,7 +819,7 @@ class DigitalWaveform(Generic[_TState]):
 
     def _validate_timing(self, value: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta]) -> None:
         if value._timestamps is not None and len(value._timestamps) != self._sample_count:
-            raise_irregular_timestamp_count_mismatch_error(
+            raise create_irregular_timestamp_count_mismatch_error(
                 len(value._timestamps), "number of samples in the waveform", self._sample_count
             )
 
@@ -890,7 +894,7 @@ class DigitalWaveform(Generic[_TState]):
         timestamps: Sequence[dt.datetime] | Sequence[ht.datetime] | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise_datatype_mismatch_error("input array", array.dtype, "waveform", self.dtype)
+            raise create_datatype_mismatch_error("input array", array.dtype, "waveform", self.dtype)
 
         if array.ndim == 1:
             array_signal_count = 1
@@ -901,12 +905,12 @@ class DigitalWaveform(Generic[_TState]):
             raise invalid_array_ndim("input array", "one or two-dimensional array", array.ndim)
 
         if array_signal_count != self.signal_count:
-            raise_signal_count_mismatch_error(
+            raise create_signal_count_mismatch_error(
                 "input array", array_signal_count, "waveform", self.signal_count
             )
 
         if timestamps is not None and len(array) != len(timestamps):
-            raise_irregular_timestamp_count_mismatch_error(
+            raise create_irregular_timestamp_count_mismatch_error(
                 len(timestamps), "input array length", len(array)
             )
 
@@ -925,7 +929,7 @@ class DigitalWaveform(Generic[_TState]):
     def _append_waveforms(self, waveforms: Sequence[DigitalWaveform[_TState]]) -> None:
         for waveform in waveforms:
             if waveform.dtype != self.dtype:
-                raise_datatype_mismatch_error(
+                raise create_datatype_mismatch_error(
                     "input waveform", waveform.dtype, "waveform", self.dtype
                 )
 
@@ -979,7 +983,7 @@ class DigitalWaveform(Generic[_TState]):
         signal_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise_datatype_mismatch_error("input array", array.dtype, "waveform", self.dtype)
+            raise create_datatype_mismatch_error("input array", array.dtype, "waveform", self.dtype)
 
         if array.ndim == 1:
             array_signal_count = 1
@@ -990,7 +994,7 @@ class DigitalWaveform(Generic[_TState]):
             raise invalid_array_ndim("input array", "one or two-dimensional array", array.ndim)
 
         if self._timing._timestamps is not None and len(array) != len(self._timing._timestamps):
-            raise_irregular_timestamp_count_mismatch_error(
+            raise create_irregular_timestamp_count_mismatch_error(
                 len(self._timing._timestamps), "input array length", len(array), reversed=True
             )
 
@@ -999,7 +1003,7 @@ class DigitalWaveform(Generic[_TState]):
         signal_count = arg_to_uint("signal count", signal_count, array_signal_count)
 
         if signal_count != array_signal_count:
-            raise_signal_count_mismatch_error(
+            raise create_signal_count_mismatch_error(
                 "input array", signal_count, "waveform", array_signal_count
             )
 
@@ -1038,15 +1042,15 @@ class DigitalWaveform(Generic[_TState]):
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_sample)
 
         if self.signal_count != expected_waveform.signal_count:
-            raise_signal_count_mismatch_error(
+            raise create_signal_count_mismatch_error(
                 "expected waveform", expected_waveform.signal_count, "waveform", self.signal_count
             )
         if start_sample + sample_count > self.sample_count:
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_sample, sample_count, "number of samples in the waveform", self.sample_count
             )
         if expected_start_sample + sample_count > expected_waveform.sample_count:
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 expected_start_sample,
                 sample_count,
                 "number of samples in the expected waveform",

--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -925,7 +925,9 @@ class DigitalWaveform(Generic[_TState]):
     def _append_waveforms(self, waveforms: Sequence[DigitalWaveform[_TState]]) -> None:
         for waveform in waveforms:
             if waveform.dtype != self.dtype:
-                raise DatatypeMismatchError("input waveform", waveform.dtype, "waveform", self.dtype)
+                raise DatatypeMismatchError(
+                    "input waveform", waveform.dtype, "waveform", self.dtype
+                )
 
         new_timing = self._timing
         for waveform in waveforms:
@@ -997,7 +999,9 @@ class DigitalWaveform(Generic[_TState]):
         signal_count = arg_to_uint("signal count", signal_count, array_signal_count)
 
         if signal_count != array_signal_count:
-            raise SignalCountMismatchError("input array", signal_count, "waveform", array_signal_count)
+            raise SignalCountMismatchError(
+                "input array", signal_count, "waveform", array_signal_count
+            )
 
         if copy:
             if sample_count > len(self._data):

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -14,12 +14,12 @@ class CapacityMismatchError(ValueError):
 
     def __init__(self, capacity: int, array_length: int) -> None:
         """Create a CapacityMismatchError."""
-        self.message = (
+        message = (
             f"The capacity must match the input array length.\n\n"
             f"Capacity: {capacity}\n"
             f"Array length: {array_length}"
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class CapacityTooSmallError(ValueError):
@@ -27,12 +27,12 @@ class CapacityTooSmallError(ValueError):
 
     def __init__(self, capacity: int, min_capacity: int, object_description: str) -> None:
         """Create a CapacityTooSmallError."""
-        self.message = (
+        message = (
             f"The capacity must be equal to or greater than the number of samples in the {object_description}.\n\n"
             f"Capacity: {capacity}\n"
             f"Number of samples: {min_capacity}"
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class DatatypeMismatchError(TypeError):
@@ -56,12 +56,12 @@ class DatatypeMismatchError(TypeError):
             "spectrum": "Spectrum data type",
             "waveform": "Waveform data type",
         }
-        self.message = (
+        message = (
             f"The data type of the {arg_description} must match the {other_description} data type.\n\n"
             f"{arg_key[arg_description]}: {arg_dtype}\n"
             f"{other_key[other_description]}: {other_dtype}"
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class IrregularTimestampCountMismatchError(ValueError):
@@ -81,19 +81,19 @@ class IrregularTimestampCountMismatchError(ValueError):
             "number of samples in the waveform": "Number of samples",
         }
         if reversed:
-            self.message = (
+            message = (
                 "The input array length must be equal to the number of irregular timestamps.\n\n"
                 f"{other_key[other_description]}: {other}\n"
                 f"Number of timestamps: {irregular_timestamp_count}"
             )
         else:
-            self.message = (
+            message = (
                 f"The number of irregular timestamps must be equal to the {other_description}.\n\n"
                 f"Number of timestamps: {irregular_timestamp_count}\n"
                 f"{other_key[other_description]}: {other}"
             )
 
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class StartIndexTooLargeError(ValueError):
@@ -117,12 +117,12 @@ class StartIndexTooLargeError(ValueError):
             "number of samples in the spectrum": "Number of samples",
             "number of samples in the waveform": "Number of samples",
         }
-        self.message = (
+        message = (
             f"The start index must be less than or equal to the {capacity_description}.\n\n"
             f"Start index: {start_index}\n"
             f"{capacity_key[capacity_description]}: {capacity}"
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class StartIndexOrSampleCountTooLargeError(ValueError):
@@ -149,13 +149,13 @@ class StartIndexOrSampleCountTooLargeError(ValueError):
             "number of samples in the spectrum": "Number of samples",
             "number of samples in the waveform": "Number of samples",
         }
-        self.message = (
+        message = (
             f"The sum of the start index and sample count must be less than or equal to the {capacity_description}.\n\n"
             f"Start index: {start_index}\n"
             f"Sample count: {sample_count}\n"
             f"{capacity_key[capacity_description]}: {capacity}"
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class NoTimestampInformationError(RuntimeError):
@@ -163,12 +163,12 @@ class NoTimestampInformationError(RuntimeError):
 
     def __init__(self) -> None:
         """Create a NoTimestampInformationError."""
-        self.message = (
+        message = (
             "The waveform timing does not have valid timestamp information. "
             "To obtain timestamps, the waveform must be irregular or must be initialized "
             "with a valid time stamp and sample interval."
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class SampleIntervalModeMismatchError(TimingMismatchError):
@@ -176,10 +176,10 @@ class SampleIntervalModeMismatchError(TimingMismatchError):
 
     def __init__(self) -> None:
         """Create a SampleIntervalModeMismatchError."""
-        self.message = (
+        message = (
             "The timing of one or more waveforms does not match the timing of the current waveform."
         )
-        super().__init__(self.message)
+        super().__init__(message)
 
 
 class SignalCountMismatchError(ValueError):
@@ -204,9 +204,9 @@ class SignalCountMismatchError(ValueError):
             "port": "Port signal count",
             "waveform": "Waveform signal count",
         }
-        self.message = (
+        message = (
             f"The {arg_description} signal count must match the {other_description} signal count.\n\n"
             f"{arg_key[arg_description]}: {arg_signal_count}\n"
             f"{other_key[other_description]}: {other_signal_count}"
         )
-        super().__init__(self.message)
+        super().__init__(message)

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -2,211 +2,181 @@ from __future__ import annotations
 
 from typing_extensions import Literal
 
-
-class TimingMismatchError(RuntimeError):
-    """Exception used when appending waveforms with mismatched timing."""
-
-    pass
-
-
-class CapacityMismatchError(ValueError):
-    """An error for an invalid capacity."""
-
-    def __init__(self, capacity: int, array_length: int) -> None:
-        """Create a CapacityMismatchError."""
-        message = (
-            f"The capacity must match the input array length.\n\n"
-            f"Capacity: {capacity}\n"
-            f"Array length: {array_length}"
-        )
-        super().__init__(message)
+from nitypes.waveform.exceptions import (
+    CapacityMismatchError,
+    CapacityTooSmallError,
+    DatatypeMismatchError,
+    IrregularTimestampCountMismatchError,
+    StartIndexTooLargeError,
+    StartIndexOrSampleCountTooLargeError,
+    NoTimestampInformationError,
+    SampleIntervalModeMismatchError,
+    SignalCountMismatchError,
+)
 
 
-class CapacityTooSmallError(ValueError):
+def raise_capacity_mismatch_error(capacity: int, array_length: int) -> None:
+    """Raise an error for an invalid capacity."""
+    message = (
+        f"The capacity must match the input array length.\n\n"
+        f"Capacity: {capacity}\n"
+        f"Array length: {array_length}"
+    )
+    raise CapacityMismatchError(message)
+
+
+def raise_capacity_too_small_error(
+    capacity: int, min_capacity: int, object_description: str
+) -> None:
     """An error for an invalid capacity argument."""
+    message = (
+        f"The capacity must be equal to or greater than the number of samples in the {object_description}.\n\n"
+        f"Capacity: {capacity}\n"
+        f"Number of samples: {min_capacity}"
+    )
+    raise CapacityTooSmallError(message)
 
-    def __init__(self, capacity: int, min_capacity: int, object_description: str) -> None:
-        """Create a CapacityTooSmallError."""
+
+def raise_datatype_mismatch_error(
+    arg_description: Literal["input array", "input spectrum", "input waveform"],
+    arg_dtype: object,
+    other_description: Literal["requested", "spectrum", "waveform"],
+    other_dtype: object,
+) -> None:
+    """Raise an error for a data type mismatch."""
+    arg_key = {
+        "input array": "Input array data type",
+        "input spectrum": "Input spectrum data type",
+        "input waveform": "Input waveform data type",
+    }
+    other_key = {
+        "requested": "Requested data type",
+        "spectrum": "Spectrum data type",
+        "waveform": "Waveform data type",
+    }
+    message = (
+        f"The data type of the {arg_description} must match the {other_description} data type.\n\n"
+        f"{arg_key[arg_description]}: {arg_dtype}\n"
+        f"{other_key[other_description]}: {other_dtype}"
+    )
+    raise DatatypeMismatchError(message)
+
+
+def raise_irregular_timestamp_count_mismatch_error(
+    irregular_timestamp_count: int,
+    other_description: Literal["input array length", "number of samples in the waveform"],
+    other: int,
+    *,
+    reversed: bool = False,
+) -> None:
+    """Raise an error for an irregular timestamp count mismatch."""
+    other_key = {
+        "input array length": "Array length",
+        "number of samples in the waveform": "Number of samples",
+    }
+    if reversed:
         message = (
-            f"The capacity must be equal to or greater than the number of samples in the {object_description}.\n\n"
-            f"Capacity: {capacity}\n"
-            f"Number of samples: {min_capacity}"
+            "The input array length must be equal to the number of irregular timestamps.\n\n"
+            f"{other_key[other_description]}: {other}\n"
+            f"Number of timestamps: {irregular_timestamp_count}"
         )
-        super().__init__(message)
-
-
-class DatatypeMismatchError(TypeError):
-    """An error for a data type mismatch."""
-
-    def __init__(
-        self,
-        arg_description: Literal["input array", "input spectrum", "input waveform"],
-        arg_dtype: object,
-        other_description: Literal["requested", "spectrum", "waveform"],
-        other_dtype: object,
-    ) -> None:
-        """Create a TypeError for a data type mismatch."""
-        arg_key = {
-            "input array": "Input array data type",
-            "input spectrum": "Input spectrum data type",
-            "input waveform": "Input waveform data type",
-        }
-        other_key = {
-            "requested": "Requested data type",
-            "spectrum": "Spectrum data type",
-            "waveform": "Waveform data type",
-        }
+    else:
         message = (
-            f"The data type of the {arg_description} must match the {other_description} data type.\n\n"
-            f"{arg_key[arg_description]}: {arg_dtype}\n"
-            f"{other_key[other_description]}: {other_dtype}"
+            f"The number of irregular timestamps must be equal to the {other_description}.\n\n"
+            f"Number of timestamps: {irregular_timestamp_count}\n"
+            f"{other_key[other_description]}: {other}"
         )
-        super().__init__(message)
+    raise IrregularTimestampCountMismatchError(message)
 
 
-class IrregularTimestampCountMismatchError(ValueError):
-    """An error for an irregular timestamp count mismatch."""
-
-    def __init__(
-        self,
-        irregular_timestamp_count: int,
-        other_description: Literal["input array length", "number of samples in the waveform"],
-        other: int,
-        *,
-        reversed: bool = False,
-    ) -> None:
-        """Create a IrregularTimestampCountMismatchError."""
-        other_key = {
-            "input array length": "Array length",
-            "number of samples in the waveform": "Number of samples",
-        }
-        if reversed:
-            message = (
-                "The input array length must be equal to the number of irregular timestamps.\n\n"
-                f"{other_key[other_description]}: {other}\n"
-                f"Number of timestamps: {irregular_timestamp_count}"
-            )
-        else:
-            message = (
-                f"The number of irregular timestamps must be equal to the {other_description}.\n\n"
-                f"Number of timestamps: {irregular_timestamp_count}\n"
-                f"{other_key[other_description]}: {other}"
-            )
-
-        super().__init__(message)
+def raise_start_index_too_large_error(
+    start_index: int,
+    capacity_description: Literal[
+        "capacity",
+        "input array length",
+        "number of samples in the spectrum",
+        "number of samples in the waveform",
+    ],
+    capacity: int,
+) -> None:
+    """Raise an error for an invalid start index argument."""
+    capacity_key = {
+        "capacity": "Capacity",
+        "input array length": "Array length",
+        "number of samples in the spectrum": "Number of samples",
+        "number of samples in the waveform": "Number of samples",
+    }
+    message = (
+        f"The start index must be less than or equal to the {capacity_description}.\n\n"
+        f"Start index: {start_index}\n"
+        f"{capacity_key[capacity_description]}: {capacity}"
+    )
+    raise StartIndexTooLargeError(message)
 
 
-class StartIndexTooLargeError(ValueError):
-    """Create a ValueError for an invalid start index argument."""
-
-    def __init__(
-        self,
-        start_index: int,
-        capacity_description: Literal[
-            "capacity",
-            "input array length",
-            "number of samples in the spectrum",
-            "number of samples in the waveform",
-        ],
-        capacity: int,
-    ) -> None:
-        """Create a StartIndexTooLargeError."""
-        capacity_key = {
-            "capacity": "Capacity",
-            "input array length": "Array length",
-            "number of samples in the spectrum": "Number of samples",
-            "number of samples in the waveform": "Number of samples",
-        }
-        message = (
-            f"The start index must be less than or equal to the {capacity_description}.\n\n"
-            f"Start index: {start_index}\n"
-            f"{capacity_key[capacity_description]}: {capacity}"
-        )
-        super().__init__(message)
-
-
-class StartIndexOrSampleCountTooLargeError(ValueError):
-    """An error for an invalid start index or sample count argument."""
-
-    def __init__(
-        self,
-        start_index: int,
-        sample_count: int,
-        capacity_description: Literal[
-            "capacity",
-            "input array length",
-            "number of samples in the expected waveform",
-            "number of samples in the spectrum",
-            "number of samples in the waveform",
-        ],
-        capacity: int,
-    ) -> None:
-        """Create a StartIndexOrSampleCountTooLargeError."""
-        capacity_key = {
-            "capacity": "Capacity",
-            "input array length": "Array length",
-            "number of samples in the expected waveform": "Number of samples",
-            "number of samples in the spectrum": "Number of samples",
-            "number of samples in the waveform": "Number of samples",
-        }
-        message = (
-            f"The sum of the start index and sample count must be less than or equal to the {capacity_description}.\n\n"
-            f"Start index: {start_index}\n"
-            f"Sample count: {sample_count}\n"
-            f"{capacity_key[capacity_description]}: {capacity}"
-        )
-        super().__init__(message)
+def raise_start_index_or_sample_count_too_large_error(
+    start_index: int,
+    sample_count: int,
+    capacity_description: Literal[
+        "capacity",
+        "input array length",
+        "number of samples in the expected waveform",
+        "number of samples in the spectrum",
+        "number of samples in the waveform",
+    ],
+    capacity: int,
+) -> None:
+    """Raise an error for an invalid start index or sample count argument."""
+    capacity_key = {
+        "capacity": "Capacity",
+        "input array length": "Array length",
+        "number of samples in the expected waveform": "Number of samples",
+        "number of samples in the spectrum": "Number of samples",
+        "number of samples in the waveform": "Number of samples",
+    }
+    message = (
+        f"The sum of the start index and sample count must be less than or equal to the {capacity_description}.\n\n"
+        f"Start index: {start_index}\n"
+        f"Sample count: {sample_count}\n"
+        f"{capacity_key[capacity_description]}: {capacity}"
+    )
+    raise StartIndexOrSampleCountTooLargeError(message)
 
 
-class NoTimestampInformationError(RuntimeError):
-    """An error for waveform timing with no timestamp information."""
-
-    def __init__(self) -> None:
-        """Create a NoTimestampInformationError."""
-        message = (
-            "The waveform timing does not have valid timestamp information. "
-            "To obtain timestamps, the waveform must be irregular or must be initialized "
-            "with a valid time stamp and sample interval."
-        )
-        super().__init__(message)
+def raise_no_timestamp_information_error() -> None:
+    """Raise an error for waveform timing with no timestamp information."""
+    raise NoTimestampInformationError()
 
 
-class SampleIntervalModeMismatchError(TimingMismatchError):
-    """An error for mixing none/regular with irregular timing."""
-
-    def __init__(self) -> None:
-        """Create a SampleIntervalModeMismatchError."""
-        message = (
-            "The timing of one or more waveforms does not match the timing of the current waveform."
-        )
-        super().__init__(message)
+def raise_sample_interval_mode_mismatch_error() -> None:
+    """Raise an error for mixing none/regular with irregular timing."""
+    message = (
+        "The timing of one or more waveforms does not match the timing of the current waveform."
+    )
+    raise SampleIntervalModeMismatchError(message)
 
 
-class SignalCountMismatchError(ValueError):
+def raise_signal_count_mismatch_error(
+    arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
+    arg_signal_count: int,
+    other_description: Literal["array", "port", "waveform"],
+    other_signal_count: int,
+) -> None:
     """An error for a mismatched signal count."""
-
-    def __init__(
-        self,
-        arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
-        arg_signal_count: int,
-        other_description: Literal["array", "port", "waveform"],
-        other_signal_count: int,
-    ) -> None:
-        """Create a SignalCountMismatchError."""
-        arg_key = {
-            "expected waveform": "Expected waveform signal count",
-            "input array": "Input array signal count",
-            "input waveform": "Input waveform signal count",
-            "provided": "Signal count",
-        }
-        other_key = {
-            "array": "Array signal count",
-            "port": "Port signal count",
-            "waveform": "Waveform signal count",
-        }
-        message = (
-            f"The {arg_description} signal count must match the {other_description} signal count.\n\n"
-            f"{arg_key[arg_description]}: {arg_signal_count}\n"
-            f"{other_key[other_description]}: {other_signal_count}"
-        )
-        super().__init__(message)
+    arg_key = {
+        "expected waveform": "Expected waveform signal count",
+        "input array": "Input array signal count",
+        "input waveform": "Input waveform signal count",
+        "provided": "Signal count",
+    }
+    other_key = {
+        "array": "Array signal count",
+        "port": "Port signal count",
+        "waveform": "Waveform signal count",
+    }
+    message = (
+        f"The {arg_description} signal count must match the {other_description} signal count.\n\n"
+        f"{arg_key[arg_description]}: {arg_signal_count}\n"
+        f"{other_key[other_description]}: {other_signal_count}"
+    )
+    raise SignalCountMismatchError(message)

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -9,162 +9,198 @@ class TimingMismatchError(RuntimeError):
     pass
 
 
-def capacity_mismatch(capacity: int, array_length: int) -> ValueError:
-    """Create a ValueError for an invalid capacity."""
-    return ValueError(
-        f"The capacity must match the input array length.\n\n"
-        f"Capacity: {capacity}\n"
-        f"Array length: {array_length}"
-    )
+class CapacityMismatchError(Exception):
+    """An error for an invalid capacity."""
 
-
-def capacity_too_small(capacity: int, min_capacity: int, object_description: str) -> ValueError:
-    """Create a ValueError for an invalid capacity argument."""
-    return ValueError(
-        f"The capacity must be equal to or greater than the number of samples in the {object_description}.\n\n"
-        f"Capacity: {capacity}\n"
-        f"Number of samples: {min_capacity}"
-    )
-
-
-def data_type_mismatch(
-    arg_description: Literal["input array", "input spectrum", "input waveform"],
-    arg_dtype: object,
-    other_description: Literal["requested", "spectrum", "waveform"],
-    other_dtype: object,
-) -> TypeError:
-    """Create a TypeError for a data type mismatch."""
-    arg_key = {
-        "input array": "Input array data type",
-        "input spectrum": "Input spectrum data type",
-        "input waveform": "Input waveform data type",
-    }
-    other_key = {
-        "requested": "Requested data type",
-        "spectrum": "Spectrum data type",
-        "waveform": "Waveform data type",
-    }
-    return TypeError(
-        f"The data type of the {arg_description} must match the {other_description} data type.\n\n"
-        f"{arg_key[arg_description]}: {arg_dtype}\n"
-        f"{other_key[other_description]}: {other_dtype}"
-    )
-
-
-def irregular_timestamp_count_mismatch(
-    irregular_timestamp_count: int,
-    other_description: Literal["input array length", "number of samples in the waveform"],
-    other: int,
-    *,
-    reversed: bool = False,
-) -> ValueError:
-    """Create a ValueError for an irregular timestamp count mismatch."""
-    other_key = {
-        "input array length": "Array length",
-        "number of samples in the waveform": "Number of samples",
-    }
-    if reversed:
-        raise ValueError(
-            "The input array length must be equal to the number of irregular timestamps.\n\n"
-            f"{other_key[other_description]}: {other}\n"
-            f"Number of timestamps: {irregular_timestamp_count}"
+    def __init__(self, capacity: int, array_length: int) -> None:
+        """Create a CapacityMismatchError."""
+        self.message = (
+            f"The capacity must match the input array length.\n\n"
+            f"Capacity: {capacity}\n"
+            f"Array length: {array_length}"
         )
-    else:
-        raise ValueError(
-            f"The number of irregular timestamps must be equal to the {other_description}.\n\n"
-            f"Number of timestamps: {irregular_timestamp_count}\n"
-            f"{other_key[other_description]}: {other}"
+        super().__init__(self.message)
+
+
+class CapacityTooSmallError(Exception):
+    """An error for an invalid capacity argument."""
+
+    def __init__(self, capacity: int, min_capacity: int, object_description: str) -> None:
+        """Create a CapacityTooSmallError."""
+        self.message = (
+            f"The capacity must be equal to or greater than the number of samples in the {object_description}.\n\n"
+            f"Capacity: {capacity}\n"
+            f"Number of samples: {min_capacity}"
         )
+        super().__init__(self.message)
+
+class DatatypeMismatchError(Exception):
+    """An error for a data type mismatch."""
+
+    def __init__(
+        self,
+        arg_description: Literal["input array", "input spectrum", "input waveform"],
+        arg_dtype: object,
+        other_description: Literal["requested", "spectrum", "waveform"],
+        other_dtype: object,
+    ) -> None:
+        """Create a TypeError for a data type mismatch."""
+        arg_key = {
+            "input array": "Input array data type",
+            "input spectrum": "Input spectrum data type",
+            "input waveform": "Input waveform data type",
+        }
+        other_key = {
+            "requested": "Requested data type",
+            "spectrum": "Spectrum data type",
+            "waveform": "Waveform data type",
+        }
+        self.message = (
+            f"The data type of the {arg_description} must match the {other_description} data type.\n\n"
+            f"{arg_key[arg_description]}: {arg_dtype}\n"
+            f"{other_key[other_description]}: {other_dtype}"
+        )
+        super().__init__(self.message)
 
 
-def start_index_too_large(
-    start_index: int,
-    capacity_description: Literal[
-        "capacity",
-        "input array length",
-        "number of samples in the spectrum",
-        "number of samples in the waveform",
-    ],
-    capacity: int,
-) -> ValueError:
+class IrregularTimestampCountMismatchError(Exception):
+    """An error for an irregular timestamp count mismatch."""
+    def __init__(
+        self,
+        irregular_timestamp_count: int,
+        other_description: Literal["input array length", "number of samples in the waveform"],
+        other: int,
+        *,
+        reversed: bool = False,
+    ) -> None:
+        """Create a IrregularTimestampCountMismatchError."""
+        other_key = {
+            "input array length": "Array length",
+            "number of samples in the waveform": "Number of samples",
+        }
+        if reversed:
+            self.message = (
+                "The input array length must be equal to the number of irregular timestamps.\n\n"
+                f"{other_key[other_description]}: {other}\n"
+                f"Number of timestamps: {irregular_timestamp_count}"
+            )
+        else:
+            self.message = (
+                f"The number of irregular timestamps must be equal to the {other_description}.\n\n"
+                f"Number of timestamps: {irregular_timestamp_count}\n"
+                f"{other_key[other_description]}: {other}"
+            )
+
+        super().__init__(self.message)
+
+
+class StartIndexTooLargeError(Exception):
     """Create a ValueError for an invalid start index argument."""
-    capacity_key = {
-        "capacity": "Capacity",
-        "input array length": "Array length",
-        "number of samples in the spectrum": "Number of samples",
-        "number of samples in the waveform": "Number of samples",
-    }
-    return ValueError(
-        f"The start index must be less than or equal to the {capacity_description}.\n\n"
-        f"Start index: {start_index}\n"
-        f"{capacity_key[capacity_description]}: {capacity}"
-    )
+
+    def __init__(
+        self,
+        start_index: int,
+        capacity_description: Literal[
+            "capacity",
+            "input array length",
+            "number of samples in the spectrum",
+            "number of samples in the waveform",
+        ],
+        capacity: int,
+    ) -> None:
+        """Create a StartIndexTooLargeError."""
+        capacity_key = {
+            "capacity": "Capacity",
+            "input array length": "Array length",
+            "number of samples in the spectrum": "Number of samples",
+            "number of samples in the waveform": "Number of samples",
+        }
+        self.message = (
+            f"The start index must be less than or equal to the {capacity_description}.\n\n"
+            f"Start index: {start_index}\n"
+            f"{capacity_key[capacity_description]}: {capacity}"
+        )
+        super().__init__(self.message)
 
 
-def start_index_or_sample_count_too_large(
-    start_index: int,
-    sample_count: int,
-    capacity_description: Literal[
-        "capacity",
-        "input array length",
-        "number of samples in the expected waveform",
-        "number of samples in the spectrum",
-        "number of samples in the waveform",
-    ],
-    capacity: int,
-) -> ValueError:
-    """Create a ValueError for an invalid start index or sample count argument."""
-    capacity_key = {
-        "capacity": "Capacity",
-        "input array length": "Array length",
-        "number of samples in the expected waveform": "Number of samples",
-        "number of samples in the spectrum": "Number of samples",
-        "number of samples in the waveform": "Number of samples",
-    }
-    return ValueError(
-        f"The sum of the start index and sample count must be less than or equal to the {capacity_description}.\n\n"
-        f"Start index: {start_index}\n"
-        f"Sample count: {sample_count}\n"
-        f"{capacity_key[capacity_description]}: {capacity}"
-    )
+class StartIndexOrSampleCountTooLargeError(Exception):
+    """An error for an invalid start index or sample count argument."""
+    def __init__(
+        self,
+        start_index: int,
+        sample_count: int,
+        capacity_description: Literal[
+            "capacity",
+            "input array length",
+            "number of samples in the expected waveform",
+            "number of samples in the spectrum",
+            "number of samples in the waveform",
+        ],
+        capacity: int,
+    ) -> None:
+        """Create a StartIndexOrSampleCountTooLargeError."""
+        capacity_key = {
+            "capacity": "Capacity",
+            "input array length": "Array length",
+            "number of samples in the expected waveform": "Number of samples",
+            "number of samples in the spectrum": "Number of samples",
+            "number of samples in the waveform": "Number of samples",
+        }
+        self.message = (
+            f"The sum of the start index and sample count must be less than or equal to the {capacity_description}.\n\n"
+            f"Start index: {start_index}\n"
+            f"Sample count: {sample_count}\n"
+            f"{capacity_key[capacity_description]}: {capacity}"
+        )
+        super().__init__(self.message)
 
 
-def no_timestamp_information() -> RuntimeError:
-    """Create a RuntimeError for waveform timing with no timestamp information."""
-    return RuntimeError(
-        "The waveform timing does not have valid timestamp information. "
-        "To obtain timestamps, the waveform must be irregular or must be initialized "
-        "with a valid time stamp and sample interval."
-    )
+class NoTimestampInformationError(Exception):
+    """An error for waveform timing with no timestamp information."""
+
+    def __init__(self) -> None:
+        """Create a NoTimestampInformationError."""
+        self.message = (
+            "The waveform timing does not have valid timestamp information. "
+            "To obtain timestamps, the waveform must be irregular or must be initialized "
+            "with a valid time stamp and sample interval."
+        )
+        super().__init__(self.message)
+
+class SampleIntervalModeMismatchError(Exception):
+    """An error for mixing none/regular with irregular timing."""
+
+    def __init__(self) -> None:
+        """Create a SampleIntervalModeMismatchError."""
+        self.message = (
+            "The timing of one or more waveforms does not match the timing of the current waveform."
+        )
+        super().__init__(self.message)
 
 
-def sample_interval_mode_mismatch() -> TimingMismatchError:
-    """Create a TimingMismatchError about mixing none/regular with irregular timing."""
-    return TimingMismatchError(
-        "The timing of one or more waveforms does not match the timing of the current waveform."
-    )
-
-
-def signal_count_mismatch(
-    arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
-    arg_signal_count: int,
-    other_description: Literal["array", "port", "waveform"],
-    other_signal_count: int,
-) -> ValueError:
-    """Create a ValueError for an mismatched signal count."""
-    arg_key = {
-        "expected waveform": "Expected waveform signal count",
-        "input array": "Input array signal count",
-        "input waveform": "Input waveform signal count",
-        "provided": "Signal count",
-    }
-    other_key = {
-        "array": "Array signal count",
-        "port": "Port signal count",
-        "waveform": "Waveform signal count",
-    }
-    return ValueError(
-        f"The {arg_description} signal count must match the {other_description} signal count.\n\n"
-        f"{arg_key[arg_description]}: {arg_signal_count}\n"
-        f"{other_key[other_description]}: {other_signal_count}"
-    )
+class SignalCountMismatchError(Exception):
+    def SignalCountMismatchError(
+        self,
+        arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
+        arg_signal_count: int,
+        other_description: Literal["array", "port", "waveform"],
+        other_signal_count: int,
+    ) -> None:
+        """Create a ValueError for an mismatched signal count."""
+        arg_key = {
+            "expected waveform": "Expected waveform signal count",
+            "input array": "Input array signal count",
+            "input waveform": "Input waveform signal count",
+            "provided": "Signal count",
+        }
+        other_key = {
+            "array": "Array signal count",
+            "port": "Port signal count",
+            "waveform": "Waveform signal count",
+        }
+        self.message = (
+            f"The {arg_description} signal count must match the {other_description} signal count.\n\n"
+            f"{arg_key[arg_description]}: {arg_signal_count}\n"
+            f"{other_key[other_description]}: {other_signal_count}"
+        )
+        super().__init__(self.message)

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -9,7 +9,7 @@ class TimingMismatchError(RuntimeError):
     pass
 
 
-class CapacityMismatchError(Exception):
+class CapacityMismatchError(ValueError):
     """An error for an invalid capacity."""
 
     def __init__(self, capacity: int, array_length: int) -> None:
@@ -22,7 +22,7 @@ class CapacityMismatchError(Exception):
         super().__init__(self.message)
 
 
-class CapacityTooSmallError(Exception):
+class CapacityTooSmallError(ValueError):
     """An error for an invalid capacity argument."""
 
     def __init__(self, capacity: int, min_capacity: int, object_description: str) -> None:
@@ -34,7 +34,8 @@ class CapacityTooSmallError(Exception):
         )
         super().__init__(self.message)
 
-class DatatypeMismatchError(Exception):
+
+class DatatypeMismatchError(TypeError):
     """An error for a data type mismatch."""
 
     def __init__(
@@ -63,8 +64,9 @@ class DatatypeMismatchError(Exception):
         super().__init__(self.message)
 
 
-class IrregularTimestampCountMismatchError(Exception):
+class IrregularTimestampCountMismatchError(ValueError):
     """An error for an irregular timestamp count mismatch."""
+
     def __init__(
         self,
         irregular_timestamp_count: int,
@@ -94,7 +96,7 @@ class IrregularTimestampCountMismatchError(Exception):
         super().__init__(self.message)
 
 
-class StartIndexTooLargeError(Exception):
+class StartIndexTooLargeError(ValueError):
     """Create a ValueError for an invalid start index argument."""
 
     def __init__(
@@ -123,8 +125,9 @@ class StartIndexTooLargeError(Exception):
         super().__init__(self.message)
 
 
-class StartIndexOrSampleCountTooLargeError(Exception):
+class StartIndexOrSampleCountTooLargeError(ValueError):
     """An error for an invalid start index or sample count argument."""
+
     def __init__(
         self,
         start_index: int,
@@ -155,7 +158,7 @@ class StartIndexOrSampleCountTooLargeError(Exception):
         super().__init__(self.message)
 
 
-class NoTimestampInformationError(Exception):
+class NoTimestampInformationError(RuntimeError):
     """An error for waveform timing with no timestamp information."""
 
     def __init__(self) -> None:
@@ -167,7 +170,8 @@ class NoTimestampInformationError(Exception):
         )
         super().__init__(self.message)
 
-class SampleIntervalModeMismatchError(Exception):
+
+class SampleIntervalModeMismatchError(TimingMismatchError):
     """An error for mixing none/regular with irregular timing."""
 
     def __init__(self) -> None:
@@ -178,15 +182,17 @@ class SampleIntervalModeMismatchError(Exception):
         super().__init__(self.message)
 
 
-class SignalCountMismatchError(Exception):
-    def SignalCountMismatchError(
+class SignalCountMismatchError(ValueError):
+    """An error for a mismatched signal count."""
+
+    def __init__(
         self,
         arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
         arg_signal_count: int,
         other_description: Literal["array", "port", "waveform"],
         other_signal_count: int,
     ) -> None:
-        """Create a ValueError for an mismatched signal count."""
+        """Create a SignalCountMismatchError."""
         arg_key = {
             "expected waveform": "Expected waveform signal count",
             "input array": "Input array signal count",

--- a/src/nitypes/waveform/_exceptions.py
+++ b/src/nitypes/waveform/_exceptions.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing_extensions import Literal
 
-from nitypes.waveform.exceptions import (
+from nitypes.waveform.errors import (
     CapacityMismatchError,
     CapacityTooSmallError,
     DatatypeMismatchError,
@@ -15,35 +15,35 @@ from nitypes.waveform.exceptions import (
 )
 
 
-def raise_capacity_mismatch_error(capacity: int, array_length: int) -> None:
-    """Raise an error for an invalid capacity."""
+def create_capacity_mismatch_error(capacity: int, array_length: int) -> CapacityMismatchError:
+    """Create an error for a capacity-length mismatch."""
     message = (
         f"The capacity must match the input array length.\n\n"
         f"Capacity: {capacity}\n"
         f"Array length: {array_length}"
     )
-    raise CapacityMismatchError(message)
+    return CapacityMismatchError(message)
 
 
-def raise_capacity_too_small_error(
+def create_capacity_too_small_error(
     capacity: int, min_capacity: int, object_description: str
-) -> None:
-    """An error for an invalid capacity argument."""
+) -> CapacityTooSmallError:
+    """Create an error for when capacity is too small."""
     message = (
         f"The capacity must be equal to or greater than the number of samples in the {object_description}.\n\n"
         f"Capacity: {capacity}\n"
         f"Number of samples: {min_capacity}"
     )
-    raise CapacityTooSmallError(message)
+    return CapacityTooSmallError(message)
 
 
-def raise_datatype_mismatch_error(
+def create_datatype_mismatch_error(
     arg_description: Literal["input array", "input spectrum", "input waveform"],
     arg_dtype: object,
     other_description: Literal["requested", "spectrum", "waveform"],
     other_dtype: object,
-) -> None:
-    """Raise an error for a data type mismatch."""
+) -> DatatypeMismatchError:
+    """Create an error for a data type mismatch."""
     arg_key = {
         "input array": "Input array data type",
         "input spectrum": "Input spectrum data type",
@@ -59,17 +59,17 @@ def raise_datatype_mismatch_error(
         f"{arg_key[arg_description]}: {arg_dtype}\n"
         f"{other_key[other_description]}: {other_dtype}"
     )
-    raise DatatypeMismatchError(message)
+    return DatatypeMismatchError(message)
 
 
-def raise_irregular_timestamp_count_mismatch_error(
+def create_irregular_timestamp_count_mismatch_error(
     irregular_timestamp_count: int,
     other_description: Literal["input array length", "number of samples in the waveform"],
     other: int,
     *,
     reversed: bool = False,
-) -> None:
-    """Raise an error for an irregular timestamp count mismatch."""
+) -> IrregularTimestampCountMismatchError:
+    """Create an error for an irregular timestamp count mismatch."""
     other_key = {
         "input array length": "Array length",
         "number of samples in the waveform": "Number of samples",
@@ -86,10 +86,10 @@ def raise_irregular_timestamp_count_mismatch_error(
             f"Number of timestamps: {irregular_timestamp_count}\n"
             f"{other_key[other_description]}: {other}"
         )
-    raise IrregularTimestampCountMismatchError(message)
+    return IrregularTimestampCountMismatchError(message)
 
 
-def raise_start_index_too_large_error(
+def create_start_index_too_large_error(
     start_index: int,
     capacity_description: Literal[
         "capacity",
@@ -98,8 +98,8 @@ def raise_start_index_too_large_error(
         "number of samples in the waveform",
     ],
     capacity: int,
-) -> None:
-    """Raise an error for an invalid start index argument."""
+) -> StartIndexTooLargeError:
+    """Create an error for an invalid start index argument."""
     capacity_key = {
         "capacity": "Capacity",
         "input array length": "Array length",
@@ -111,10 +111,10 @@ def raise_start_index_too_large_error(
         f"Start index: {start_index}\n"
         f"{capacity_key[capacity_description]}: {capacity}"
     )
-    raise StartIndexTooLargeError(message)
+    return StartIndexTooLargeError(message)
 
 
-def raise_start_index_or_sample_count_too_large_error(
+def create_start_index_or_sample_count_too_large_error(
     start_index: int,
     sample_count: int,
     capacity_description: Literal[
@@ -125,8 +125,8 @@ def raise_start_index_or_sample_count_too_large_error(
         "number of samples in the waveform",
     ],
     capacity: int,
-) -> None:
-    """Raise an error for an invalid start index or sample count argument."""
+) -> StartIndexOrSampleCountTooLargeError:
+    """Create an error for an invalid start index or sample count argument."""
     capacity_key = {
         "capacity": "Capacity",
         "input array length": "Array length",
@@ -140,29 +140,34 @@ def raise_start_index_or_sample_count_too_large_error(
         f"Sample count: {sample_count}\n"
         f"{capacity_key[capacity_description]}: {capacity}"
     )
-    raise StartIndexOrSampleCountTooLargeError(message)
+    return StartIndexOrSampleCountTooLargeError(message)
 
 
-def raise_no_timestamp_information_error() -> None:
-    """Raise an error for waveform timing with no timestamp information."""
-    raise NoTimestampInformationError()
+def create_no_timestamp_information_error() -> NoTimestampInformationError:
+    """Create an error for waveform timing with no timestamp information."""
+    message = (
+        "The waveform timing does not have valid timestamp information. "
+        "To obtain timestamps, the waveform must be irregular or must be initialized "
+        "with a valid time stamp and sample interval."
+    )
+    return NoTimestampInformationError(message)
 
 
-def raise_sample_interval_mode_mismatch_error() -> None:
-    """Raise an error for mixing none/regular with irregular timing."""
+def create_sample_interval_mode_mismatch_error() -> SampleIntervalModeMismatchError:
+    """Create an error for mixing none/regular with irregular timing."""
     message = (
         "The timing of one or more waveforms does not match the timing of the current waveform."
     )
-    raise SampleIntervalModeMismatchError(message)
+    return SampleIntervalModeMismatchError(message)
 
 
-def raise_signal_count_mismatch_error(
+def create_signal_count_mismatch_error(
     arg_description: Literal["expected waveform", "input array", "input waveform", "provided"],
     arg_signal_count: int,
     other_description: Literal["array", "port", "waveform"],
     other_signal_count: int,
-) -> None:
-    """An error for a mismatched signal count."""
+) -> SignalCountMismatchError:
+    """Create an error for a mismatched signal count."""
     arg_key = {
         "expected waveform": "Expected waveform signal count",
         "input array": "Input array signal count",
@@ -179,4 +184,4 @@ def raise_signal_count_mismatch_error(
         f"{arg_key[arg_description]}: {arg_signal_count}\n"
         f"{other_key[other_description]}: {other_signal_count}"
     )
-    raise SignalCountMismatchError(message)
+    return SignalCountMismatchError(message)

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -16,12 +16,12 @@ from nitypes._arguments import arg_to_uint, validate_dtype, validate_unsupported
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
 from nitypes._numpy import asarray as _np_asarray
 from nitypes.waveform._exceptions import (
-    capacity_mismatch,
-    capacity_too_small,
-    data_type_mismatch,
-    irregular_timestamp_count_mismatch,
-    start_index_or_sample_count_too_large,
-    start_index_too_large,
+    CapacityMismatchError,
+    CapacityTooSmallError,
+    DatatypeMismatchError,
+    IrregularTimestampCountMismatchError,
+    StartIndexOrSampleCountTooLargeError,
+    StartIndexTooLargeError,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -290,9 +290,9 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         validate_dtype(dtype, self.__class__._get_supported_raw_dtypes())
 
         if start_index > capacity:
-            raise start_index_too_large(start_index, "capacity", capacity)
+            raise StartIndexTooLargeError(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -317,20 +317,20 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise data_type_mismatch("input array", data.dtype, "requested", np.dtype(dtype))
+            raise DatatypeMismatchError("input array", data.dtype, "requested", np.dtype(dtype))
         validate_dtype(dtype, self.__class__._get_supported_raw_dtypes())
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise capacity_mismatch(capacity, len(data))
+            raise CapacityMismatchError(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise start_index_too_large(start_index, "input array length", capacity)
+            raise StartIndexTooLargeError(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "input array length", len(data)
             )
 
@@ -357,13 +357,13 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise start_index_too_large(
+            raise StartIndexTooLargeError(
                 start_index, "number of samples in the waveform", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "number of samples in the waveform", self.sample_count
             )
 
@@ -463,7 +463,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise capacity_too_small(value, min_capacity, "waveform")
+            raise CapacityTooSmallError(value, min_capacity, "waveform")
         if value != len(self._data):
             self._data.resize(value, refcheck=False)
 
@@ -509,7 +509,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
 
     def _validate_timing(self, value: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta]) -> None:
         if value._timestamps is not None and len(value._timestamps) != self._sample_count:
-            raise irregular_timestamp_count_mismatch(
+            raise IrregularTimestampCountMismatchError(
                 len(value._timestamps), "number of samples in the waveform", self._sample_count
             )
 
@@ -604,11 +604,11 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         timestamps: Sequence[dt.datetime] | Sequence[ht.datetime] | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise data_type_mismatch("input array", array.dtype, "waveform", self.dtype)
+            raise DatatypeMismatchError("input array", array.dtype, "waveform", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
         if timestamps is not None and len(array) != len(timestamps):
-            raise irregular_timestamp_count_mismatch(
+            raise IrregularTimestampCountMismatchError(
                 len(timestamps), "input array length", len(array)
             )
 
@@ -627,7 +627,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
     def _append_waveforms(self, waveforms: Sequence[NumericWaveform[_TRaw, _TScaled]]) -> None:
         for waveform in waveforms:
             if waveform.dtype != self.dtype:
-                raise data_type_mismatch("input waveform", waveform.dtype, "waveform", self.dtype)
+                raise DatatypeMismatchError("input waveform", waveform.dtype, "waveform", self.dtype)
             if waveform._scale_mode != self._scale_mode:
                 warnings.warn(scale_mode_mismatch())
 
@@ -680,11 +680,11 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         sample_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise data_type_mismatch("input array", array.dtype, "waveform", self.dtype)
+            raise DatatypeMismatchError("input array", array.dtype, "waveform", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
         if self._timing._timestamps is not None and len(array) != len(self._timing._timestamps):
-            raise irregular_timestamp_count_mismatch(
+            raise IrregularTimestampCountMismatchError(
                 len(self._timing._timestamps), "input array length", len(array), reversed=True
             )
 

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -16,12 +16,12 @@ from nitypes._arguments import arg_to_uint, validate_dtype, validate_unsupported
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
 from nitypes._numpy import asarray as _np_asarray
 from nitypes.waveform._exceptions import (
-    CapacityMismatchError,
-    CapacityTooSmallError,
-    DatatypeMismatchError,
-    IrregularTimestampCountMismatchError,
-    StartIndexOrSampleCountTooLargeError,
-    StartIndexTooLargeError,
+    raise_capacity_mismatch_error,
+    raise_capacity_too_small_error,
+    raise_datatype_mismatch_error,
+    raise_irregular_timestamp_count_mismatch_error,
+    raise_start_index_or_sample_count_too_large_error,
+    raise_start_index_too_large_error,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -290,9 +290,9 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         validate_dtype(dtype, self.__class__._get_supported_raw_dtypes())
 
         if start_index > capacity:
-            raise StartIndexTooLargeError(start_index, "capacity", capacity)
+            raise_start_index_too_large_error(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise StartIndexOrSampleCountTooLargeError(
+            raise_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -317,20 +317,20 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise DatatypeMismatchError("input array", data.dtype, "requested", np.dtype(dtype))
+            raise_datatype_mismatch_error("input array", data.dtype, "requested", np.dtype(dtype))
         validate_dtype(dtype, self.__class__._get_supported_raw_dtypes())
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise CapacityMismatchError(capacity, len(data))
+            raise_capacity_mismatch_error(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise StartIndexTooLargeError(start_index, "input array length", capacity)
+            raise_start_index_too_large_error(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise StartIndexOrSampleCountTooLargeError(
+            raise_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "input array length", len(data)
             )
 
@@ -357,13 +357,13 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise StartIndexTooLargeError(
+            raise_start_index_too_large_error(
                 start_index, "number of samples in the waveform", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise StartIndexOrSampleCountTooLargeError(
+            raise_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "number of samples in the waveform", self.sample_count
             )
 
@@ -463,7 +463,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise CapacityTooSmallError(value, min_capacity, "waveform")
+            raise_capacity_too_small_error(value, min_capacity, "waveform")
         if value != len(self._data):
             self._data.resize(value, refcheck=False)
 
@@ -509,7 +509,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
 
     def _validate_timing(self, value: Timing[_AnyDateTime, _AnyTimeDelta, _AnyTimeDelta]) -> None:
         if value._timestamps is not None and len(value._timestamps) != self._sample_count:
-            raise IrregularTimestampCountMismatchError(
+            raise_irregular_timestamp_count_mismatch_error(
                 len(value._timestamps), "number of samples in the waveform", self._sample_count
             )
 
@@ -604,11 +604,11 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         timestamps: Sequence[dt.datetime] | Sequence[ht.datetime] | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise DatatypeMismatchError("input array", array.dtype, "waveform", self.dtype)
+            raise_datatype_mismatch_error("input array", array.dtype, "waveform", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
         if timestamps is not None and len(array) != len(timestamps):
-            raise IrregularTimestampCountMismatchError(
+            raise_irregular_timestamp_count_mismatch_error(
                 len(timestamps), "input array length", len(array)
             )
 
@@ -627,7 +627,7 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
     def _append_waveforms(self, waveforms: Sequence[NumericWaveform[_TRaw, _TScaled]]) -> None:
         for waveform in waveforms:
             if waveform.dtype != self.dtype:
-                raise DatatypeMismatchError(
+                raise_datatype_mismatch_error(
                     "input waveform", waveform.dtype, "waveform", self.dtype
                 )
             if waveform._scale_mode != self._scale_mode:
@@ -682,11 +682,11 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         sample_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise DatatypeMismatchError("input array", array.dtype, "waveform", self.dtype)
+            raise_datatype_mismatch_error("input array", array.dtype, "waveform", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
         if self._timing._timestamps is not None and len(array) != len(self._timing._timestamps):
-            raise IrregularTimestampCountMismatchError(
+            raise_irregular_timestamp_count_mismatch_error(
                 len(self._timing._timestamps), "input array length", len(array), reversed=True
             )
 

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -627,7 +627,9 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
     def _append_waveforms(self, waveforms: Sequence[NumericWaveform[_TRaw, _TScaled]]) -> None:
         for waveform in waveforms:
             if waveform.dtype != self.dtype:
-                raise DatatypeMismatchError("input waveform", waveform.dtype, "waveform", self.dtype)
+                raise DatatypeMismatchError(
+                    "input waveform", waveform.dtype, "waveform", self.dtype
+                )
             if waveform._scale_mode != self._scale_mode:
                 warnings.warn(scale_mode_mismatch())
 

--- a/src/nitypes/waveform/_spectrum.py
+++ b/src/nitypes/waveform/_spectrum.py
@@ -12,11 +12,11 @@ from nitypes._arguments import arg_to_float, arg_to_uint, validate_dtype
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
 from nitypes._numpy import asarray as _np_asarray, long as _np_long, ulong as _np_ulong
 from nitypes.waveform._exceptions import (
-    CapacityMismatchError,
-    CapacityTooSmallError,
-    DatatypeMismatchError,
-    StartIndexOrSampleCountTooLargeError,
-    StartIndexTooLargeError,
+    raise_capacity_mismatch_error,
+    raise_capacity_too_small_error,
+    raise_datatype_mismatch_error,
+    raise_start_index_or_sample_count_too_large_error,
+    raise_start_index_too_large_error,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -411,9 +411,9 @@ class Spectrum(Generic[_TData]):
         validate_dtype(dtype, _DATA_DTYPES)
 
         if start_index > capacity:
-            raise StartIndexTooLargeError(start_index, "capacity", capacity)
+            raise_start_index_too_large_error(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise StartIndexOrSampleCountTooLargeError(
+            raise_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -438,20 +438,20 @@ class Spectrum(Generic[_TData]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise DatatypeMismatchError("input array", data.dtype, "requested", np.dtype(dtype))
+            raise_datatype_mismatch_error("input array", data.dtype, "requested", np.dtype(dtype))
         validate_dtype(dtype, _DATA_DTYPES)
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise CapacityMismatchError(capacity, len(data))
+            raise_capacity_mismatch_error(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise StartIndexTooLargeError(start_index, "input array length", capacity)
+            raise_start_index_too_large_error(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise StartIndexOrSampleCountTooLargeError(
+            raise_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "input array length", len(data)
             )
 
@@ -478,13 +478,13 @@ class Spectrum(Generic[_TData]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise StartIndexTooLargeError(
+            raise_start_index_too_large_error(
                 start_index, "number of samples in the spectrum", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise StartIndexOrSampleCountTooLargeError(
+            raise_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "number of samples in the spectrum", self.sample_count
             )
 
@@ -512,7 +512,7 @@ class Spectrum(Generic[_TData]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise CapacityTooSmallError(value, min_capacity, "spectrum")
+            raise_capacity_too_small_error(value, min_capacity, "spectrum")
         if value != len(self._data):
             self._data.resize(value, refcheck=False)
 
@@ -608,7 +608,7 @@ class Spectrum(Generic[_TData]):
         array: npt.NDArray[_TData],
     ) -> None:
         if array.dtype != self.dtype:
-            raise DatatypeMismatchError("input array", array.dtype, "spectrum", self.dtype)
+            raise_datatype_mismatch_error("input array", array.dtype, "spectrum", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
 
@@ -624,7 +624,7 @@ class Spectrum(Generic[_TData]):
     def _append_spectrums(self, spectrums: Sequence[Spectrum[_TData]]) -> None:
         for spectrum in spectrums:
             if spectrum.dtype != self.dtype:
-                raise DatatypeMismatchError(
+                raise_datatype_mismatch_error(
                     "input spectrum", spectrum.dtype, "spectrum", self.dtype
                 )
 
@@ -672,7 +672,7 @@ class Spectrum(Generic[_TData]):
         sample_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise DatatypeMismatchError("input array", array.dtype, "spectrum", self.dtype)
+            raise_datatype_mismatch_error("input array", array.dtype, "spectrum", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
 

--- a/src/nitypes/waveform/_spectrum.py
+++ b/src/nitypes/waveform/_spectrum.py
@@ -12,11 +12,11 @@ from nitypes._arguments import arg_to_float, arg_to_uint, validate_dtype
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
 from nitypes._numpy import asarray as _np_asarray, long as _np_long, ulong as _np_ulong
 from nitypes.waveform._exceptions import (
-    capacity_mismatch,
-    capacity_too_small,
-    data_type_mismatch,
-    start_index_or_sample_count_too_large,
-    start_index_too_large,
+    CapacityMismatchError,
+    CapacityTooSmallError,
+    DatatypeMismatchError,
+    StartIndexOrSampleCountTooLargeError,
+    StartIndexTooLargeError,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -411,9 +411,9 @@ class Spectrum(Generic[_TData]):
         validate_dtype(dtype, _DATA_DTYPES)
 
         if start_index > capacity:
-            raise start_index_too_large(start_index, "capacity", capacity)
+            raise StartIndexTooLargeError(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -438,20 +438,20 @@ class Spectrum(Generic[_TData]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise data_type_mismatch("input array", data.dtype, "requested", np.dtype(dtype))
+            raise DatatypeMismatchError("input array", data.dtype, "requested", np.dtype(dtype))
         validate_dtype(dtype, _DATA_DTYPES)
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise capacity_mismatch(capacity, len(data))
+            raise CapacityMismatchError(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise start_index_too_large(start_index, "input array length", capacity)
+            raise StartIndexTooLargeError(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "input array length", len(data)
             )
 
@@ -478,13 +478,13 @@ class Spectrum(Generic[_TData]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise start_index_too_large(
+            raise StartIndexTooLargeError(
                 start_index, "number of samples in the spectrum", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise start_index_or_sample_count_too_large(
+            raise StartIndexOrSampleCountTooLargeError(
                 start_index, sample_count, "number of samples in the spectrum", self.sample_count
             )
 
@@ -512,7 +512,7 @@ class Spectrum(Generic[_TData]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise capacity_too_small(value, min_capacity, "spectrum")
+            raise CapacityTooSmallError(value, min_capacity, "spectrum")
         if value != len(self._data):
             self._data.resize(value, refcheck=False)
 
@@ -608,7 +608,7 @@ class Spectrum(Generic[_TData]):
         array: npt.NDArray[_TData],
     ) -> None:
         if array.dtype != self.dtype:
-            raise data_type_mismatch("input array", array.dtype, "spectrum", self.dtype)
+            raise DatatypeMismatchError("input array", array.dtype, "spectrum", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
 
@@ -624,7 +624,7 @@ class Spectrum(Generic[_TData]):
     def _append_spectrums(self, spectrums: Sequence[Spectrum[_TData]]) -> None:
         for spectrum in spectrums:
             if spectrum.dtype != self.dtype:
-                raise data_type_mismatch("input spectrum", spectrum.dtype, "spectrum", self.dtype)
+                raise DatatypeMismatchError("input spectrum", spectrum.dtype, "spectrum", self.dtype)
 
         self._increase_capacity(sum(spectrum.sample_count for spectrum in spectrums))
 
@@ -670,7 +670,7 @@ class Spectrum(Generic[_TData]):
         sample_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise data_type_mismatch("input array", array.dtype, "spectrum", self.dtype)
+            raise DatatypeMismatchError("input array", array.dtype, "spectrum", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
 

--- a/src/nitypes/waveform/_spectrum.py
+++ b/src/nitypes/waveform/_spectrum.py
@@ -12,11 +12,11 @@ from nitypes._arguments import arg_to_float, arg_to_uint, validate_dtype
 from nitypes._exceptions import invalid_arg_type, invalid_array_ndim
 from nitypes._numpy import asarray as _np_asarray, long as _np_long, ulong as _np_ulong
 from nitypes.waveform._exceptions import (
-    raise_capacity_mismatch_error,
-    raise_capacity_too_small_error,
-    raise_datatype_mismatch_error,
-    raise_start_index_or_sample_count_too_large_error,
-    raise_start_index_too_large_error,
+    create_capacity_mismatch_error,
+    create_capacity_too_small_error,
+    create_datatype_mismatch_error,
+    create_start_index_or_sample_count_too_large_error,
+    create_start_index_too_large_error,
 )
 from nitypes.waveform._extended_properties import (
     CHANNEL_NAME,
@@ -411,9 +411,9 @@ class Spectrum(Generic[_TData]):
         validate_dtype(dtype, _DATA_DTYPES)
 
         if start_index > capacity:
-            raise_start_index_too_large_error(start_index, "capacity", capacity)
+            raise create_start_index_too_large_error(start_index, "capacity", capacity)
         if start_index + sample_count > capacity:
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "capacity", capacity
             )
 
@@ -438,20 +438,22 @@ class Spectrum(Generic[_TData]):
         if dtype is None:
             dtype = data.dtype
         if dtype != data.dtype:
-            raise_datatype_mismatch_error("input array", data.dtype, "requested", np.dtype(dtype))
+            raise create_datatype_mismatch_error(
+                "input array", data.dtype, "requested", np.dtype(dtype)
+            )
         validate_dtype(dtype, _DATA_DTYPES)
 
         capacity = arg_to_uint("capacity", capacity, len(data))
         if capacity != len(data):
-            raise_capacity_mismatch_error(capacity, len(data))
+            raise create_capacity_mismatch_error(capacity, len(data))
 
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > capacity:
-            raise_start_index_too_large_error(start_index, "input array length", capacity)
+            raise create_start_index_too_large_error(start_index, "input array length", capacity)
 
         sample_count = arg_to_uint("sample count", sample_count, len(data) - start_index)
         if start_index + sample_count > len(data):
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "input array length", len(data)
             )
 
@@ -478,13 +480,13 @@ class Spectrum(Generic[_TData]):
         """
         start_index = arg_to_uint("start index", start_index, 0)
         if start_index > self.sample_count:
-            raise_start_index_too_large_error(
+            raise create_start_index_too_large_error(
                 start_index, "number of samples in the spectrum", self.sample_count
             )
 
         sample_count = arg_to_uint("sample count", sample_count, self.sample_count - start_index)
         if start_index + sample_count > self.sample_count:
-            raise_start_index_or_sample_count_too_large_error(
+            raise create_start_index_or_sample_count_too_large_error(
                 start_index, sample_count, "number of samples in the spectrum", self.sample_count
             )
 
@@ -512,7 +514,7 @@ class Spectrum(Generic[_TData]):
         value = arg_to_uint("capacity", value)
         min_capacity = self._start_index + self._sample_count
         if value < min_capacity:
-            raise_capacity_too_small_error(value, min_capacity, "spectrum")
+            raise create_capacity_too_small_error(value, min_capacity, "spectrum")
         if value != len(self._data):
             self._data.resize(value, refcheck=False)
 
@@ -608,7 +610,7 @@ class Spectrum(Generic[_TData]):
         array: npt.NDArray[_TData],
     ) -> None:
         if array.dtype != self.dtype:
-            raise_datatype_mismatch_error("input array", array.dtype, "spectrum", self.dtype)
+            raise create_datatype_mismatch_error("input array", array.dtype, "spectrum", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
 
@@ -624,7 +626,7 @@ class Spectrum(Generic[_TData]):
     def _append_spectrums(self, spectrums: Sequence[Spectrum[_TData]]) -> None:
         for spectrum in spectrums:
             if spectrum.dtype != self.dtype:
-                raise_datatype_mismatch_error(
+                raise create_datatype_mismatch_error(
                     "input spectrum", spectrum.dtype, "spectrum", self.dtype
                 )
 
@@ -672,7 +674,7 @@ class Spectrum(Generic[_TData]):
         sample_count: SupportsIndex | None = None,
     ) -> None:
         if array.dtype != self.dtype:
-            raise_datatype_mismatch_error("input array", array.dtype, "spectrum", self.dtype)
+            raise create_datatype_mismatch_error("input array", array.dtype, "spectrum", self.dtype)
         if array.ndim != 1:
             raise invalid_array_ndim("input array", "one-dimensional array", array.ndim)
 

--- a/src/nitypes/waveform/_spectrum.py
+++ b/src/nitypes/waveform/_spectrum.py
@@ -624,7 +624,9 @@ class Spectrum(Generic[_TData]):
     def _append_spectrums(self, spectrums: Sequence[Spectrum[_TData]]) -> None:
         for spectrum in spectrums:
             if spectrum.dtype != self.dtype:
-                raise DatatypeMismatchError("input spectrum", spectrum.dtype, "spectrum", self.dtype)
+                raise DatatypeMismatchError(
+                    "input spectrum", spectrum.dtype, "spectrum", self.dtype
+                )
 
         self._increase_capacity(sum(spectrum.sample_count for spectrum in spectrums))
 

--- a/src/nitypes/waveform/_timing/_sample_interval/_irregular.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_irregular.py
@@ -8,7 +8,7 @@ from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import invalid_arg_type
 from nitypes.waveform._exceptions import (
     TimingMismatchError,
-    sample_interval_mode_mismatch,
+    SampleIntervalModeMismatchError,
 )
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
@@ -121,7 +121,7 @@ class IrregularSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode != SampleIntervalMode.IRREGULAR:
-            raise sample_interval_mode_mismatch()
+            raise SampleIntervalModeMismatchError()
 
         assert timing._timestamps is not None and other._timestamps is not None
 

--- a/src/nitypes/waveform/_timing/_sample_interval/_irregular.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_irregular.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING, final
 
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import invalid_arg_type
-from nitypes.waveform._exceptions import (
-    TimingMismatchError,
-    SampleIntervalModeMismatchError,
-)
+from nitypes.waveform._exceptions import raise_sample_interval_mode_mismatch_error
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
 from nitypes.waveform._timing._types import (
@@ -19,6 +16,7 @@ from nitypes.waveform._timing._types import (
     _TTimestamp,
     _TTimestamp_co,
 )
+from nitypes.waveform.exceptions import TimingMismatchError
 
 if TYPE_CHECKING:
     from nitypes.waveform._timing._timing import Timing  # circular import
@@ -121,7 +119,7 @@ class IrregularSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode != SampleIntervalMode.IRREGULAR:
-            raise SampleIntervalModeMismatchError()
+            raise_sample_interval_mode_mismatch_error()
 
         assert timing._timestamps is not None and other._timestamps is not None
 

--- a/src/nitypes/waveform/_timing/_sample_interval/_irregular.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_irregular.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, final
 
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import invalid_arg_type
-from nitypes.waveform._exceptions import raise_sample_interval_mode_mismatch_error
+from nitypes.waveform._exceptions import create_sample_interval_mode_mismatch_error
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
 from nitypes.waveform._timing._types import (
@@ -16,7 +16,7 @@ from nitypes.waveform._timing._types import (
     _TTimestamp,
     _TTimestamp_co,
 )
-from nitypes.waveform.exceptions import TimingMismatchError
+from nitypes.waveform.errors import TimingMismatchError
 
 if TYPE_CHECKING:
     from nitypes.waveform._timing._timing import Timing  # circular import
@@ -119,7 +119,7 @@ class IrregularSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode != SampleIntervalMode.IRREGULAR:
-            raise_sample_interval_mode_mismatch_error()
+            raise create_sample_interval_mode_mismatch_error()
 
         assert timing._timestamps is not None and other._timestamps is not None
 

--- a/src/nitypes/waveform/_timing/_sample_interval/_none.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_none.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING, final
 
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import add_note, invalid_arg_type
-from nitypes.waveform._exceptions import (
-    NoTimestampInformationError,
-    SampleIntervalModeMismatchError,
-)
+from nitypes.waveform._exceptions import raise_sample_interval_mode_mismatch_error
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
 from nitypes.waveform._timing._types import (
@@ -20,6 +17,7 @@ from nitypes.waveform._timing._types import (
     _TTimestamp_co,
 )
 from nitypes.waveform._warnings import sample_interval_mismatch
+from nitypes.waveform.exceptions import NoTimestampInformationError
 
 if TYPE_CHECKING:
     from nitypes.waveform._timing._timing import Timing  # circular import
@@ -73,7 +71,7 @@ class NoneSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode not in (SampleIntervalMode.NONE, SampleIntervalMode.REGULAR):
-            raise SampleIntervalModeMismatchError()
+            raise_sample_interval_mode_mismatch_error()
         if timing._sample_interval != other._sample_interval:
             warnings.warn(sample_interval_mismatch())
         return timing

--- a/src/nitypes/waveform/_timing/_sample_interval/_none.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_none.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING, final
 
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import add_note, invalid_arg_type
-from nitypes.waveform._exceptions import raise_sample_interval_mode_mismatch_error
+from nitypes.waveform._exceptions import (
+    create_no_timestamp_information_error,
+    create_sample_interval_mode_mismatch_error,
+)
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
 from nitypes.waveform._timing._types import (
@@ -17,7 +20,6 @@ from nitypes.waveform._timing._types import (
     _TTimestamp_co,
 )
 from nitypes.waveform._warnings import sample_interval_mismatch
-from nitypes.waveform.exceptions import NoTimestampInformationError
 
 if TYPE_CHECKING:
     from nitypes.waveform._timing._timing import Timing  # circular import
@@ -51,7 +53,7 @@ class NoneSampleIntervalStrategy(
         start_index: int,
         count: int,
     ) -> Iterable[_TTimestamp_co]:
-        raise NoTimestampInformationError()
+        raise create_no_timestamp_information_error()
 
     def append_timestamps(  # noqa: D102 - Missing docstring in public method - override
         self,
@@ -71,7 +73,7 @@ class NoneSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode not in (SampleIntervalMode.NONE, SampleIntervalMode.REGULAR):
-            raise_sample_interval_mode_mismatch_error()
+            raise create_sample_interval_mode_mismatch_error()
         if timing._sample_interval != other._sample_interval:
             warnings.warn(sample_interval_mismatch())
         return timing

--- a/src/nitypes/waveform/_timing/_sample_interval/_none.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_none.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, final
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import add_note, invalid_arg_type
 from nitypes.waveform._exceptions import (
-    no_timestamp_information,
-    sample_interval_mode_mismatch,
+    NoTimestampInformationError,
+    SampleIntervalModeMismatchError,
 )
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
@@ -53,7 +53,7 @@ class NoneSampleIntervalStrategy(
         start_index: int,
         count: int,
     ) -> Iterable[_TTimestamp_co]:
-        raise no_timestamp_information()
+        raise NoTimestampInformationError()
 
     def append_timestamps(  # noqa: D102 - Missing docstring in public method - override
         self,
@@ -73,7 +73,7 @@ class NoneSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode not in (SampleIntervalMode.NONE, SampleIntervalMode.REGULAR):
-            raise sample_interval_mode_mismatch()
+            raise SampleIntervalModeMismatchError()
         if timing._sample_interval != other._sample_interval:
             warnings.warn(sample_interval_mismatch())
         return timing

--- a/src/nitypes/waveform/_timing/_sample_interval/_regular.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_regular.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, cast, final
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import add_note, invalid_arg_type
 from nitypes.waveform._exceptions import (
-    no_timestamp_information,
-    sample_interval_mode_mismatch,
+    NoTimestampInformationError,
+    SampleIntervalModeMismatchError,
 )
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
@@ -56,7 +56,7 @@ class RegularSampleIntervalStrategy(
     ) -> Iterable[_TTimestamp_co]:
         if timing.has_timestamp:
             return self._generate_regular_timestamps(timing, start_index, count)
-        raise no_timestamp_information()
+        raise NoTimestampInformationError()
 
     def _generate_regular_timestamps(
         self,
@@ -90,7 +90,7 @@ class RegularSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode not in (SampleIntervalMode.NONE, SampleIntervalMode.REGULAR):
-            raise sample_interval_mode_mismatch()
+            raise SampleIntervalModeMismatchError()
         if timing._sample_interval != other._sample_interval:
             warnings.warn(sample_interval_mismatch())
         return timing

--- a/src/nitypes/waveform/_timing/_sample_interval/_regular.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_regular.py
@@ -6,10 +6,7 @@ from typing import TYPE_CHECKING, cast, final
 
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import add_note, invalid_arg_type
-from nitypes.waveform._exceptions import (
-    NoTimestampInformationError,
-    SampleIntervalModeMismatchError,
-)
+from nitypes.waveform._exceptions import raise_sample_interval_mode_mismatch_error
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
 from nitypes.waveform._timing._types import (
@@ -20,6 +17,7 @@ from nitypes.waveform._timing._types import (
     _TTimestamp_co,
 )
 from nitypes.waveform._warnings import sample_interval_mismatch
+from nitypes.waveform.exceptions import NoTimestampInformationError
 
 if TYPE_CHECKING:
     from nitypes.waveform._timing._timing import Timing  # circular import
@@ -90,7 +88,7 @@ class RegularSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode not in (SampleIntervalMode.NONE, SampleIntervalMode.REGULAR):
-            raise SampleIntervalModeMismatchError()
+            raise_sample_interval_mode_mismatch_error()
         if timing._sample_interval != other._sample_interval:
             warnings.warn(sample_interval_mismatch())
         return timing

--- a/src/nitypes/waveform/_timing/_sample_interval/_regular.py
+++ b/src/nitypes/waveform/_timing/_sample_interval/_regular.py
@@ -6,7 +6,10 @@ from typing import TYPE_CHECKING, cast, final
 
 from nitypes._arguments import validate_unsupported_arg
 from nitypes._exceptions import add_note, invalid_arg_type
-from nitypes.waveform._exceptions import raise_sample_interval_mode_mismatch_error
+from nitypes.waveform._exceptions import (
+    create_no_timestamp_information_error,
+    create_sample_interval_mode_mismatch_error,
+)
 from nitypes.waveform._timing._sample_interval._base import SampleIntervalStrategy
 from nitypes.waveform._timing._sample_interval._mode import SampleIntervalMode
 from nitypes.waveform._timing._types import (
@@ -17,7 +20,6 @@ from nitypes.waveform._timing._types import (
     _TTimestamp_co,
 )
 from nitypes.waveform._warnings import sample_interval_mismatch
-from nitypes.waveform.exceptions import NoTimestampInformationError
 
 if TYPE_CHECKING:
     from nitypes.waveform._timing._timing import Timing  # circular import
@@ -54,7 +56,7 @@ class RegularSampleIntervalStrategy(
     ) -> Iterable[_TTimestamp_co]:
         if timing.has_timestamp:
             return self._generate_regular_timestamps(timing, start_index, count)
-        raise NoTimestampInformationError()
+        raise create_no_timestamp_information_error()
 
     def _generate_regular_timestamps(
         self,
@@ -88,7 +90,7 @@ class RegularSampleIntervalStrategy(
         other: Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co],
     ) -> Timing[_TTimestamp_co, _TTimeOffset_co, _TSampleInterval_co]:
         if other._sample_interval_mode not in (SampleIntervalMode.NONE, SampleIntervalMode.REGULAR):
-            raise_sample_interval_mode_mismatch_error()
+            raise create_sample_interval_mode_mismatch_error()
         if timing._sample_interval != other._sample_interval:
             warnings.warn(sample_interval_mismatch())
         return timing

--- a/src/nitypes/waveform/errors.py
+++ b/src/nitypes/waveform/errors.py
@@ -48,14 +48,7 @@ class StartIndexOrSampleCountTooLargeError(ValueError):
 class NoTimestampInformationError(RuntimeError):
     """An error for waveform timing with no timestamp information."""
 
-    def __init__(self) -> None:
-        """Create a NoTimestampInformationError."""
-        message = (
-            "The waveform timing does not have valid timestamp information. "
-            "To obtain timestamps, the waveform must be irregular or must be initialized "
-            "with a valid time stamp and sample interval."
-        )
-        super().__init__(message)
+    pass
 
 
 class SampleIntervalModeMismatchError(TimingMismatchError):

--- a/src/nitypes/waveform/exceptions.py
+++ b/src/nitypes/waveform/exceptions.py
@@ -34,7 +34,7 @@ class IrregularTimestampCountMismatchError(ValueError):
 
 
 class StartIndexTooLargeError(ValueError):
-    """Create a ValueError for an invalid start index argument."""
+    """An error for an invalid start index argument."""
 
     pass
 

--- a/src/nitypes/waveform/exceptions.py
+++ b/src/nitypes/waveform/exceptions.py
@@ -1,0 +1,70 @@
+"""Custom error classes for waveforms."""
+
+from __future__ import annotations
+
+
+class TimingMismatchError(RuntimeError):
+    """Exception used when appending waveforms with mismatched timing."""
+
+    pass
+
+
+class CapacityMismatchError(ValueError):
+    """An error for an invalid capacity."""
+
+    pass
+
+
+class CapacityTooSmallError(ValueError):
+    """An error for an invalid capacity argument."""
+
+    pass
+
+
+class DatatypeMismatchError(TypeError):
+    """An error for a data type mismatch."""
+
+    pass
+
+
+class IrregularTimestampCountMismatchError(ValueError):
+    """An error for an irregular timestamp count mismatch."""
+
+    pass
+
+
+class StartIndexTooLargeError(ValueError):
+    """Create a ValueError for an invalid start index argument."""
+
+    pass
+
+
+class StartIndexOrSampleCountTooLargeError(ValueError):
+    """An error for an invalid start index or sample count argument."""
+
+    pass
+
+
+class NoTimestampInformationError(RuntimeError):
+    """An error for waveform timing with no timestamp information."""
+
+    def __init__(self) -> None:
+        """Create a NoTimestampInformationError."""
+        message = (
+            "The waveform timing does not have valid timestamp information. "
+            "To obtain timestamps, the waveform must be irregular or must be initialized "
+            "with a valid time stamp and sample interval."
+        )
+        super().__init__(message)
+
+
+class SampleIntervalModeMismatchError(TimingMismatchError):
+    """An error for mixing none/regular with irregular timing."""
+
+    pass
+
+
+class SignalCountMismatchError(ValueError):
+    """An error for a mismatched signal count."""
+
+    pass

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -9,6 +9,7 @@ import pytest
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
+import nitypes.waveform._exceptions as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 
@@ -328,11 +329,11 @@ def test___timestamps_tuple___create_with_irregular_interval___creates_timing_wi
 ###############################################################################
 # get_timestamps
 ###############################################################################
-def test___no_interval___get_timestamps___raises_runtime_error() -> None:
+def test___no_interval___get_timestamps___raises_correct_error() -> None:
     start_time = bt.DateTime.now(dt.timezone.utc)
     timing = Timing.create_with_no_interval(start_time)
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(wfmex.NoTimestampInformationError) as exc:
         _ = timing.get_timestamps(0, 5)
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -9,7 +9,7 @@ import pytest
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-import nitypes.waveform._exceptions as wfmex
+import nitypes.waveform.exceptions as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 

--- a/tests/unit/waveform/_timing/test_bintime.py
+++ b/tests/unit/waveform/_timing/test_bintime.py
@@ -9,7 +9,7 @@ import pytest
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-import nitypes.waveform.exceptions as wfmex
+import nitypes.waveform.errors as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -8,6 +8,7 @@ from typing import Any
 import pytest
 from typing_extensions import assert_type
 
+import nitypes.waveform._exceptions as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 
@@ -319,11 +320,11 @@ def test___timestamps_tuple___create_with_irregular_interval___creates_timing_wi
 ###############################################################################
 # get_timestamps
 ###############################################################################
-def test___no_interval___get_timestamps___raises_runtime_error() -> None:
+def test___no_interval___get_timestamps___raises_correct_error() -> None:
     start_time = dt.datetime.now(dt.timezone.utc)
     timing = Timing.create_with_no_interval(start_time)
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(wfmex.NoTimestampInformationError) as exc:
         _ = timing.get_timestamps(0, 5)
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 from typing_extensions import assert_type
 
-import nitypes.waveform._exceptions as wfmex
+import nitypes.waveform.exceptions as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 

--- a/tests/unit/waveform/_timing/test_datetime.py
+++ b/tests/unit/waveform/_timing/test_datetime.py
@@ -8,7 +8,7 @@ from typing import Any
 import pytest
 from typing_extensions import assert_type
 
-import nitypes.waveform.exceptions as wfmex
+import nitypes.waveform.errors as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -9,6 +9,7 @@ import hightime as ht
 import pytest
 from typing_extensions import assert_type
 
+import nitypes.waveform._exceptions as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 
@@ -320,11 +321,11 @@ def test___timestamps_tuple___create_with_irregular_interval___creates_timing_wi
 ###############################################################################
 # get_timestamps
 ###############################################################################
-def test___no_interval___get_timestamps___raises_runtime_error() -> None:
+def test___no_interval___get_timestamps___raises_correct_error() -> None:
     start_time = ht.datetime.now(dt.timezone.utc)
     timing = Timing.create_with_no_interval(start_time)
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(wfmex.NoTimestampInformationError) as exc:
         _ = timing.get_timestamps(0, 5)
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -9,7 +9,7 @@ import hightime as ht
 import pytest
 from typing_extensions import assert_type
 
-import nitypes.waveform._exceptions as wfmex
+import nitypes.waveform.exceptions as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 

--- a/tests/unit/waveform/_timing/test_hightime.py
+++ b/tests/unit/waveform/_timing/test_hightime.py
@@ -9,7 +9,7 @@ import hightime as ht
 import pytest
 from typing_extensions import assert_type
 
-import nitypes.waveform.exceptions as wfmex
+import nitypes.waveform.errors as wfmex
 from nitypes.waveform import SampleIntervalMode, Timing
 from tests.unit.waveform._timing._utils import assert_deep_copy, assert_shallow_copy
 

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -339,7 +339,7 @@ def test___invalid_array_subset___from_array_1d___raises_correct_error(
     start_index: SupportsIndex,
     sample_count: SupportsIndex | None,
     expected_message: str,
-    exception_type: type,
+    exception_type: type[Exception],
 ) -> None:
     data = np.array([1, 2, 3, 4, 5], np.int32)
 
@@ -621,7 +621,7 @@ def test___invalid_array_subset___from_array_2d___raises_correct_error(
     start_index: SupportsIndex,
     sample_count: SupportsIndex | None,
     expected_message: str,
-    exception_type: type,
+    exception_type: type[Exception],
 ) -> None:
     data = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], np.int32)
 
@@ -732,7 +732,7 @@ def test___array_subset___get_raw_data___returns_array_subset(
     ],
 )
 def test___invalid_array_subset___get_raw_data___returns_array_subset(
-    start_index: int, sample_count: int, expected_message: str, exception_type: type
+    start_index: int, sample_count: int, expected_message: str, exception_type: type[Exception]
 ) -> None:
     waveform = AnalogWaveform.from_array_1d([0, 1, 2, 3], np.int32)
     waveform.scale_mode = LinearScaleMode(2.0, 0.5)
@@ -891,7 +891,7 @@ def test___waveform___set_capacity___resizes_array_and_pads_with_zeros(
     ],
 )
 def test___invalid_capacity___set_capacity___raises_correct_error(
-    capacity: int, expected_message: str, exception_type: type
+    capacity: int, expected_message: str, exception_type: type[Exception]
 ) -> None:
     data = [1, 2, 3]
     waveform = AnalogWaveform.from_array_1d(data, np.int32)

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -18,7 +18,7 @@ from packaging.version import Version
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-import nitypes.waveform._exceptions as wfmex
+import nitypes.waveform.exceptions as wfmex
 from nitypes.waveform import (
     NO_SCALING,
     AnalogWaveform,

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -18,7 +18,7 @@ from packaging.version import Version
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-import nitypes.waveform.exceptions as wfmex
+import nitypes.waveform.errors as wfmex
 from nitypes.waveform import (
     NO_SCALING,
     AnalogWaveform,

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -18,6 +18,7 @@ from packaging.version import Version
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
+import nitypes.waveform._exceptions as wfmex
 from nitypes.waveform import (
     NO_SCALING,
     AnalogWaveform,
@@ -1499,7 +1500,7 @@ def test___ndarray_with_mismatched_dtype___load_data___raises_type_error() -> No
     waveform = AnalogWaveform.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.load_data(array)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -303,36 +303,47 @@ def test___array_subset___from_array_1d___creates_waveform_with_array_subset(
 
 
 @pytest.mark.parametrize(
-    "start_index, sample_count, expected_message",
+    "start_index, sample_count, expected_message, exception_type",
     [
-        (-2, None, "The start index must be a non-negative integer."),
-        (-1, None, "The start index must be a non-negative integer."),
-        (6, None, "The start index must be less than or equal to the input array length."),
-        (0, -2, "The sample count must be a non-negative integer."),
-        (0, -1, "The sample count must be a non-negative integer."),
+        (-2, None, "The start index must be a non-negative integer.", ValueError),
+        (-1, None, "The start index must be a non-negative integer.", ValueError),
+        (
+            6,
+            None,
+            "The start index must be less than or equal to the input array length.",
+            wfmex.StartIndexTooLargeError,
+        ),
+        (0, -2, "The sample count must be a non-negative integer.", ValueError),
+        (0, -1, "The sample count must be a non-negative integer.", ValueError),
         (
             0,
             6,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             1,
             5,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             5,
             1,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
     ],
 )
-def test___invalid_array_subset___from_array_1d___raises_value_error(
-    start_index: SupportsIndex, sample_count: SupportsIndex | None, expected_message: str
+def test___invalid_array_subset___from_array_1d___raises_correct_error(
+    start_index: SupportsIndex,
+    sample_count: SupportsIndex | None,
+    expected_message: str,
+    exception_type: type,
 ) -> None:
     data = np.array([1, 2, 3, 4, 5], np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(exception_type) as exc:
         _ = AnalogWaveform.from_array_1d(data, start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -574,36 +585,47 @@ def test___array_subset___from_array_2d___creates_waveform_with_array_subset(
 
 
 @pytest.mark.parametrize(
-    "start_index, sample_count, expected_message",
+    "start_index, sample_count, expected_message, exception_type",
     [
-        (-2, None, "The start index must be a non-negative integer."),
-        (-1, None, "The start index must be a non-negative integer."),
-        (6, None, "The start index must be less than or equal to the input array length."),
-        (0, -2, "The sample count must be a non-negative integer."),
-        (0, -1, "The sample count must be a non-negative integer."),
+        (-2, None, "The start index must be a non-negative integer.", ValueError),
+        (-1, None, "The start index must be a non-negative integer.", ValueError),
+        (
+            6,
+            None,
+            "The start index must be less than or equal to the input array length.",
+            wfmex.StartIndexTooLargeError,
+        ),
+        (0, -2, "The sample count must be a non-negative integer.", ValueError),
+        (0, -1, "The sample count must be a non-negative integer.", ValueError),
         (
             0,
             6,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             1,
             5,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             5,
             1,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
     ],
 )
-def test___invalid_array_subset___from_array_2d___raises_value_error(
-    start_index: SupportsIndex, sample_count: SupportsIndex | None, expected_message: str
+def test___invalid_array_subset___from_array_2d___raises_correct_error(
+    start_index: SupportsIndex,
+    sample_count: SupportsIndex | None,
+    expected_message: str,
+    exception_type: type,
 ) -> None:
     data = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(exception_type) as exc:
         _ = AnalogWaveform.from_array_2d(data, start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -687,32 +709,35 @@ def test___array_subset___get_raw_data___returns_array_subset(
 
 
 @pytest.mark.parametrize(
-    "start_index, sample_count, expected_message",
+    "start_index, sample_count, expected_message, exception_type",
     [
         (
             5,
             None,
             "The start index must be less than or equal to the number of samples in the waveform.",
+            wfmex.StartIndexTooLargeError,
         ),
         (
             0,
             5,
             "The sum of the start index and sample count must be less than or equal to the number of samples in the waveform.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             4,
             1,
             "The sum of the start index and sample count must be less than or equal to the number of samples in the waveform.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
     ],
 )
 def test___invalid_array_subset___get_raw_data___returns_array_subset(
-    start_index: int, sample_count: int, expected_message: str
+    start_index: int, sample_count: int, expected_message: str, exception_type: type
 ) -> None:
     waveform = AnalogWaveform.from_array_1d([0, 1, 2, 3], np.int32)
     waveform.scale_mode = LinearScaleMode(2.0, 0.5)
 
-    with pytest.raises((TypeError, ValueError)) as exc:
+    with pytest.raises(exception_type) as exc:
         _ = waveform.get_raw_data(start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -849,21 +874,29 @@ def test___waveform___set_capacity___resizes_array_and_pads_with_zeros(
 
 
 @pytest.mark.parametrize(
-    "capacity, expected_message",
+    "capacity, expected_message, exception_type",
     [
-        (-2, "The capacity must be a non-negative integer."),
-        (-1, "The capacity must be a non-negative integer."),
-        (0, "The capacity must be equal to or greater than the number of samples in the waveform."),
-        (2, "The capacity must be equal to or greater than the number of samples in the waveform."),
+        (-2, "The capacity must be a non-negative integer.", ValueError),
+        (-1, "The capacity must be a non-negative integer.", ValueError),
+        (
+            0,
+            "The capacity must be equal to or greater than the number of samples in the waveform.",
+            wfmex.CapacityTooSmallError,
+        ),
+        (
+            2,
+            "The capacity must be equal to or greater than the number of samples in the waveform.",
+            wfmex.CapacityTooSmallError,
+        ),
     ],
 )
-def test___invalid_capacity___set_capacity___raises_value_error(
-    capacity: int, expected_message: str
+def test___invalid_capacity___set_capacity___raises_correct_error(
+    capacity: int, expected_message: str, exception_type: type
 ) -> None:
     data = [1, 2, 3]
     waveform = AnalogWaveform.from_array_1d(data, np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(exception_type) as exc:
         waveform.capacity = capacity
 
     assert exc.value.args[0].startswith(expected_message)
@@ -1082,11 +1115,11 @@ def test___float64_ndarray___append___appends_array() -> None:
     assert list(waveform.raw_data) == [0, 1, 2, 3, 4, 5]
 
 
-def test___ndarray_with_mismatched_dtype___append___raises_type_error() -> None:
+def test___ndarray_with_mismatched_dtype___append___raises_correct_error() -> None:
     waveform = AnalogWaveform.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.append(array)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -1142,7 +1175,7 @@ def test___irregular_waveform_and_int32_ndarray_without_timestamps___append___ra
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___irregular_waveform_and_int32_ndarray_with_wrong_timestamp_count___append___raises_value_error_and_does_not_append() -> (
+def test___irregular_waveform_and_int32_ndarray_with_wrong_timestamp_count___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1154,7 +1187,7 @@ def test___irregular_waveform_and_int32_ndarray_with_wrong_timestamp_count___app
     array_timestamps = [start_time + offset for offset in array_offsets]
     array = np.array([3, 4, 5], np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(wfmex.IrregularTimestampCountMismatchError) as exc:
         waveform.append(array, array_timestamps)
 
     assert exc.value.args[0].startswith(
@@ -1165,7 +1198,7 @@ def test___irregular_waveform_and_int32_ndarray_with_wrong_timestamp_count___app
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___regular_waveform_and_int32_ndarray_with_timestamps___append___raises_runtime_error_and_does_not_append() -> (
+def test___regular_waveform_and_int32_ndarray_with_timestamps___append___raises_value_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1214,11 +1247,11 @@ def test___float64_waveform___append___appends_waveform() -> None:
     assert list(waveform.raw_data) == [0, 1, 2, 3, 4, 5]
 
 
-def test___waveform_with_mismatched_dtype___append___raises_type_error() -> None:
+def test___waveform_with_mismatched_dtype___append___raises_correct_error() -> None:
     waveform = AnalogWaveform.from_array_1d([0, 1, 2], np.float64)
     other = AnalogWaveform.from_array_1d([3, 4, 5], np.int32)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.append(other)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -1244,9 +1277,7 @@ def test___irregular_waveform_and_irregular_waveform___append___appends_waveform
     assert waveform.timing._timestamps == waveform_timestamps + other_timestamps
 
 
-def test___irregular_waveform_and_regular_waveform___append___raises_timing_mismatch_error() -> (
-    None
-):
+def test___irregular_waveform_and_regular_waveform___append___raises_correct_error() -> None:
     start_time = dt.datetime.now(dt.timezone.utc)
     waveform_offsets = [dt.timedelta(0), dt.timedelta(1), dt.timedelta(2)]
     waveform_timestamps = [start_time + offset for offset in waveform_offsets]
@@ -1254,7 +1285,7 @@ def test___irregular_waveform_and_regular_waveform___append___raises_timing_mism
     waveform.timing = Timing.create_with_irregular_interval(waveform_timestamps)
     other = AnalogWaveform.from_array_1d([3, 4, 5], np.int32)
 
-    with pytest.raises(TimingMismatchError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1265,9 +1296,7 @@ def test___irregular_waveform_and_regular_waveform___append___raises_timing_mism
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___regular_waveform_and_irregular_waveform___append___raises_timing_mismatch_error() -> (
-    None
-):
+def test___regular_waveform_and_irregular_waveform___append___raises_correct_error() -> None:
     start_time = dt.datetime.now(dt.timezone.utc)
     waveform = AnalogWaveform.from_array_1d([0, 1, 2], np.int32)
     waveform.timing = Timing.create_with_regular_interval(dt.timedelta(milliseconds=1))
@@ -1276,7 +1305,7 @@ def test___regular_waveform_and_irregular_waveform___append___raises_timing_mism
     other = AnalogWaveform.from_array_1d([3, 4, 5], np.int32)
     other.timing = Timing.create_with_irregular_interval(other_timestamps)
 
-    with pytest.raises(TimingMismatchError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1371,7 +1400,7 @@ def test___float64_waveform_tuple___append___appends_waveform() -> None:
     assert list(waveform.raw_data) == [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 
-def test___waveform_list_with_mismatched_dtype___append___raises_type_error_and_does_not_append() -> (
+def test___waveform_list_with_mismatched_dtype___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     waveform = AnalogWaveform.from_array_1d([0, 1, 2], np.float64)
@@ -1380,7 +1409,7 @@ def test___waveform_list_with_mismatched_dtype___append___raises_type_error_and_
         AnalogWaveform.from_array_1d([6, 7, 8], np.int32),
     ]
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.append(other)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -1414,7 +1443,7 @@ def test___irregular_waveform_and_irregular_waveform_list___append___appends_wav
     )
 
 
-def test___irregular_waveform_and_regular_waveform_list___append___raises_timing_mismatch_error_and_does_not_append() -> (
+def test___irregular_waveform_and_regular_waveform_list___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1430,7 +1459,7 @@ def test___irregular_waveform_and_regular_waveform_list___append___raises_timing
     other2.timing = Timing.create_with_regular_interval(dt.timedelta(milliseconds=1))
     other = [other1, other2]
 
-    with pytest.raises(TimingMismatchError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1441,7 +1470,7 @@ def test___irregular_waveform_and_regular_waveform_list___append___raises_timing
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___regular_waveform_and_irregular_waveform_list___append___raises_runtime_error_and_does_not_append() -> (
+def test___regular_waveform_and_irregular_waveform_list___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1455,7 +1484,7 @@ def test___regular_waveform_and_irregular_waveform_list___append___raises_runtim
     other2.timing = Timing.create_with_irregular_interval(other2_timestamps)
     other = [other1, other2]
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1496,7 +1525,7 @@ def test___float64_ndarray___load_data___overwrites_data() -> None:
     assert list(waveform.raw_data) == [3, 4, 5]
 
 
-def test___ndarray_with_mismatched_dtype___load_data___raises_type_error() -> None:
+def test___ndarray_with_mismatched_dtype___load_data___raises_correct_error() -> None:
     waveform = AnalogWaveform.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 
@@ -1609,7 +1638,7 @@ def test___irregular_waveform_and_int32_ndarray_with_timestamps___load_data___ov
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___irregular_waveform_and_int32_ndarray_with_wrong_sample_count___load_data___raises_value_error_and_does_not_overwrite_data() -> (
+def test___irregular_waveform_and_int32_ndarray_with_wrong_sample_count___load_data___raises_correct_error_and_does_not_overwrite_data() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1619,7 +1648,7 @@ def test___irregular_waveform_and_int32_ndarray_with_wrong_sample_count___load_d
     waveform.timing = Timing.create_with_irregular_interval(waveform_timestamps)
     array = np.array([3, 4], np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(wfmex.IrregularTimestampCountMismatchError) as exc:
         waveform.load_data(array)
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -15,8 +15,8 @@ import pytest
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-from nitypes._numpy import bool as _np_bool
 import nitypes.waveform._exceptions as wfmex
+from nitypes._numpy import bool as _np_bool
 from nitypes.waveform import (
     DigitalState,
     DigitalWaveform,
@@ -518,31 +518,34 @@ def test___array_subset___get_data___returns_array_subset(
 
 
 @pytest.mark.parametrize(
-    "start_index, sample_count, expected_message",
+    "start_index, sample_count, expected_message, exception_type",
     [
         (
             5,
             None,
             "The start index must be less than or equal to the number of samples in the waveform.",
+            wfmex.StartIndexTooLargeError,
         ),
         (
             0,
             5,
             "The sum of the start index and sample count must be less than or equal to the number of samples in the waveform.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             4,
             1,
             "The sum of the start index and sample count must be less than or equal to the number of samples in the waveform.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
     ],
 )
 def test___invalid_array_subset___get_data___returns_array_subset(
-    start_index: int, sample_count: int, expected_message: str
+    start_index: int, sample_count: int, expected_message: str, exception_type: type
 ) -> None:
     waveform = DigitalWaveform.from_lines([0, 1, 2, 3], np.uint8)
 
-    with pytest.raises((TypeError, ValueError)) as exc:
+    with pytest.raises((exception_type)) as exc:
         _ = waveform.get_data(start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -573,21 +576,29 @@ def test___waveform___set_capacity___resizes_array_and_pads_with_zeros(
 
 
 @pytest.mark.parametrize(
-    "capacity, expected_message",
+    "capacity, expected_message, exception_type",
     [
-        (-2, "The capacity must be a non-negative integer."),
-        (-1, "The capacity must be a non-negative integer."),
-        (0, "The capacity must be equal to or greater than the number of samples in the waveform."),
-        (2, "The capacity must be equal to or greater than the number of samples in the waveform."),
+        (-2, "The capacity must be a non-negative integer.", ValueError),
+        (-1, "The capacity must be a non-negative integer.", ValueError),
+        (
+            0,
+            "The capacity must be equal to or greater than the number of samples in the waveform.",
+            wfmex.CapacityTooSmallError,
+        ),
+        (
+            2,
+            "The capacity must be equal to or greater than the number of samples in the waveform.",
+            wfmex.CapacityTooSmallError,
+        ),
     ],
 )
-def test___invalid_capacity___set_capacity___raises_value_error(
-    capacity: int, expected_message: str
+def test___invalid_capacity___set_capacity___raises_correct_error(
+    capacity: int, expected_message: str, exception_type: type
 ) -> None:
     data = [1, 2, 3]
     waveform = DigitalWaveform.from_lines(data, np.uint8)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(exception_type) as exc:
         waveform.capacity = capacity
 
     assert exc.value.args[0].startswith(expected_message)
@@ -777,11 +788,11 @@ def test___bool_ndarray___append___appends_array() -> None:
     assert waveform.data.tolist() == [[False], [True], [False], [True], [False], [True]]
 
 
-def test___ndarray_with_mismatched_dtype___append___raises_type_error() -> None:
+def test___ndarray_with_mismatched_dtype___append___raises_correct_error() -> None:
     waveform = DigitalWaveform.from_lines([0, 1, 2], _np_bool)
     array = np.array([3, 4, 5], np.uint8)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.append(array)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -836,7 +847,7 @@ def test___irregular_waveform_and_uint8_ndarray_without_timestamps___append___ra
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___irregular_waveform_and_uint8_ndarray_with_wrong_timestamp_count___append___raises_value_error_and_does_not_append() -> (
+def test___irregular_waveform_and_uint8_ndarray_with_wrong_timestamp_count___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -848,7 +859,7 @@ def test___irregular_waveform_and_uint8_ndarray_with_wrong_timestamp_count___app
     array_timestamps = [start_time + offset for offset in array_offsets]
     array = np.array([3, 4, 5], np.uint8)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(wfmex.IrregularTimestampCountMismatchError) as exc:
         waveform.append(array, array_timestamps)
 
     assert exc.value.args[0].startswith(
@@ -859,7 +870,7 @@ def test___irregular_waveform_and_uint8_ndarray_with_wrong_timestamp_count___app
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___regular_waveform_and_uint8_ndarray_with_timestamps___append___raises_runtime_error_and_does_not_append() -> (
+def test___regular_waveform_and_uint8_ndarray_with_timestamps___append___raises_value_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -908,11 +919,11 @@ def test___bool_waveform___append___appends_waveform() -> None:
     assert waveform.data.tolist() == [[False], [True], [False], [True], [False], [True]]
 
 
-def test___waveform_with_mismatched_dtype___append___raises_type_error() -> None:
+def test___waveform_with_mismatched_dtype___append___raises_correct_error() -> None:
     waveform = DigitalWaveform.from_lines([[False], [True], [False]], _np_bool)
     other = DigitalWaveform.from_lines([[3], [4], [5]], np.uint8)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.append(other)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -938,9 +949,7 @@ def test___irregular_waveform_and_irregular_waveform___append___appends_waveform
     assert waveform.timing._timestamps == waveform_timestamps + other_timestamps
 
 
-def test___irregular_waveform_and_regular_waveform___append___raises_timing_mismatch_error() -> (
-    None
-):
+def test___irregular_waveform_and_regular_waveform___append___raises_correct_error() -> None:
     start_time = dt.datetime.now(dt.timezone.utc)
     waveform_offsets = [dt.timedelta(0), dt.timedelta(1), dt.timedelta(2)]
     waveform_timestamps = [start_time + offset for offset in waveform_offsets]
@@ -948,7 +957,7 @@ def test___irregular_waveform_and_regular_waveform___append___raises_timing_mism
     waveform.timing = Timing.create_with_irregular_interval(waveform_timestamps)
     other = DigitalWaveform.from_lines([[3], [4], [5]], np.uint8)
 
-    with pytest.raises(TimingMismatchError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -959,9 +968,7 @@ def test___irregular_waveform_and_regular_waveform___append___raises_timing_mism
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___regular_waveform_and_irregular_waveform___append___raises_timing_mismatch_error() -> (
-    None
-):
+def test___regular_waveform_and_irregular_waveform___append___raises_correct_error() -> None:
     start_time = dt.datetime.now(dt.timezone.utc)
     waveform = DigitalWaveform.from_lines([[0], [1], [2]], np.uint8)
     waveform.timing = Timing.create_with_regular_interval(dt.timedelta(milliseconds=1))
@@ -970,7 +977,7 @@ def test___regular_waveform_and_irregular_waveform___append___raises_timing_mism
     other = DigitalWaveform.from_lines([[3], [4], [5]], np.uint8)
     other.timing = Timing.create_with_irregular_interval(other_timestamps)
 
-    with pytest.raises(TimingMismatchError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1060,7 +1067,7 @@ def test___bool_waveform_tuple___append___appends_waveform() -> None:
     ]
 
 
-def test___waveform_list_with_mismatched_dtype___append___raises_type_error_and_does_not_append() -> (
+def test___waveform_list_with_mismatched_dtype___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     waveform = DigitalWaveform.from_lines([[False], [True], [False]], _np_bool)
@@ -1069,7 +1076,7 @@ def test___waveform_list_with_mismatched_dtype___append___raises_type_error_and_
         DigitalWaveform.from_lines([[6], [7], [8]], np.uint8),
     ]
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.append(other)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -1103,7 +1110,7 @@ def test___irregular_waveform_and_irregular_waveform_list___append___appends_wav
     )
 
 
-def test___irregular_waveform_and_regular_waveform_list___append___raises_timing_mismatch_error_and_does_not_append() -> (
+def test___irregular_waveform_and_regular_waveform_list___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1119,7 +1126,7 @@ def test___irregular_waveform_and_regular_waveform_list___append___raises_timing
     other2.timing = Timing.create_with_regular_interval(dt.timedelta(milliseconds=1))
     other = [other1, other2]
 
-    with pytest.raises(TimingMismatchError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1130,7 +1137,7 @@ def test___irregular_waveform_and_regular_waveform_list___append___raises_timing
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___regular_waveform_and_irregular_waveform_list___append___raises_runtime_error_and_does_not_append() -> (
+def test___regular_waveform_and_irregular_waveform_list___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1144,7 +1151,7 @@ def test___regular_waveform_and_irregular_waveform_list___append___raises_runtim
     other2.timing = Timing.create_with_irregular_interval(other2_timestamps)
     other = [other1, other2]
 
-    with pytest.raises(RuntimeError) as exc:
+    with pytest.raises(wfmex.SampleIntervalModeMismatchError) as exc:
         waveform.append(other)
 
     assert exc.value.args[0].startswith(
@@ -1185,7 +1192,7 @@ def test___bool_ndarray___load_data___overwrites_data() -> None:
     assert waveform.data.tolist() == [[True], [False], [True]]
 
 
-def test___ndarray_with_mismatched_dtype___load_data___raises_type_error() -> None:
+def test___ndarray_with_mismatched_dtype___load_data___raises_correct_error() -> None:
     waveform = DigitalWaveform.from_lines([[False], [True], [False]], _np_bool)
     array = np.array([[3], [4], [5]], np.uint8)
 
@@ -1297,7 +1304,7 @@ def test___irregular_waveform_and_uint8_ndarray_with_timestamps___load_data___ov
     assert waveform.timing._timestamps == waveform_timestamps
 
 
-def test___irregular_waveform_and_uint8_ndarray_with_wrong_sample_count___load_data___raises_value_error_and_does_not_overwrite_data() -> (
+def test___irregular_waveform_and_uint8_ndarray_with_wrong_sample_count___load_data___raises_correct_error_and_does_not_overwrite_data() -> (
     None
 ):
     start_time = dt.datetime.now(dt.timezone.utc)
@@ -1307,7 +1314,7 @@ def test___irregular_waveform_and_uint8_ndarray_with_wrong_sample_count___load_d
     waveform.timing = Timing.create_with_irregular_interval(waveform_timestamps)
     array = np.array([3, 4], np.uint8)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(wfmex.IrregularTimestampCountMismatchError) as exc:
         waveform.load_data(array)
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -15,7 +15,7 @@ import pytest
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-import nitypes.waveform.exceptions as wfmex
+import nitypes.waveform.errors as wfmex
 from nitypes._numpy import bool as _np_bool
 from nitypes.waveform import (
     DigitalState,

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -16,6 +16,7 @@ from typing_extensions import assert_type
 
 import nitypes.bintime as bt
 from nitypes._numpy import bool as _np_bool
+import nitypes.waveform._exceptions as wfmex
 from nitypes.waveform import (
     DigitalState,
     DigitalWaveform,
@@ -1188,7 +1189,7 @@ def test___ndarray_with_mismatched_dtype___load_data___raises_type_error() -> No
     waveform = DigitalWaveform.from_lines([[False], [True], [False]], _np_bool)
     array = np.array([[3], [4], [5]], np.uint8)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         waveform.load_data(array)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -545,7 +545,7 @@ def test___invalid_array_subset___get_data___returns_array_subset(
 ) -> None:
     waveform = DigitalWaveform.from_lines([0, 1, 2, 3], np.uint8)
 
-    with pytest.raises((exception_type)) as exc:
+    with pytest.raises(exception_type) as exc:
         _ = waveform.get_data(start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -15,7 +15,7 @@ import pytest
 from typing_extensions import assert_type
 
 import nitypes.bintime as bt
-import nitypes.waveform._exceptions as wfmex
+import nitypes.waveform.exceptions as wfmex
 from nitypes._numpy import bool as _np_bool
 from nitypes.waveform import (
     DigitalState,

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -541,7 +541,7 @@ def test___array_subset___get_data___returns_array_subset(
     ],
 )
 def test___invalid_array_subset___get_data___returns_array_subset(
-    start_index: int, sample_count: int, expected_message: str, exception_type: type
+    start_index: int, sample_count: int, expected_message: str, exception_type: type[Exception]
 ) -> None:
     waveform = DigitalWaveform.from_lines([0, 1, 2, 3], np.uint8)
 
@@ -593,7 +593,7 @@ def test___waveform___set_capacity___resizes_array_and_pads_with_zeros(
     ],
 )
 def test___invalid_capacity___set_capacity___raises_correct_error(
-    capacity: int, expected_message: str, exception_type: type
+    capacity: int, expected_message: str, exception_type: type[Exception]
 ) -> None:
     data = [1, 2, 3]
     waveform = DigitalWaveform.from_lines(data, np.uint8)

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -14,7 +14,7 @@ import pytest
 from packaging.version import Version
 from typing_extensions import assert_type
 
-import nitypes.waveform.exceptions as wfmex
+import nitypes.waveform.errors as wfmex
 from nitypes.waveform import Spectrum
 
 

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -14,7 +14,7 @@ import pytest
 from packaging.version import Version
 from typing_extensions import assert_type
 
-import nitypes.waveform._exceptions as wfmex
+import nitypes.waveform.exceptions as wfmex
 from nitypes.waveform import Spectrum
 
 

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -14,6 +14,7 @@ import pytest
 from packaging.version import Version
 from typing_extensions import assert_type
 
+import nitypes.waveform._exceptions as wfmex
 from nitypes.waveform import Spectrum
 
 
@@ -996,7 +997,7 @@ def test___ndarray_with_mismatched_dtype___load_data___raises_type_error() -> No
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         spectrum.load_data(array)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -736,7 +736,7 @@ def test___invalid_capacity___set_capacity___raises_correct_error(
     data = [1, 2, 3]
     spectrum = Spectrum.from_array_1d(data, np.int32)
 
-    with pytest.raises((exception_type)) as exc:
+    with pytest.raises(exception_type) as exc:
         spectrum.capacity = capacity
 
     assert exc.value.args[0].startswith(expected_message)

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -286,36 +286,47 @@ def test___array_subset___from_array_1d___creates_spectrum_with_array_subset(
 
 
 @pytest.mark.parametrize(
-    "start_index, sample_count, expected_message",
+    "start_index, sample_count, expected_message, exception_type",
     [
-        (-2, None, "The start index must be a non-negative integer."),
-        (-1, None, "The start index must be a non-negative integer."),
-        (6, None, "The start index must be less than or equal to the input array length."),
-        (0, -2, "The sample count must be a non-negative integer."),
-        (0, -1, "The sample count must be a non-negative integer."),
+        (-2, None, "The start index must be a non-negative integer.", ValueError),
+        (-1, None, "The start index must be a non-negative integer.", ValueError),
+        (
+            6,
+            None,
+            "The start index must be less than or equal to the input array length.",
+            wfmex.StartIndexTooLargeError,
+        ),
+        (0, -2, "The sample count must be a non-negative integer.", ValueError),
+        (0, -1, "The sample count must be a non-negative integer.", ValueError),
         (
             0,
             6,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             1,
             5,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             5,
             1,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
     ],
 )
-def test___invalid_array_subset___from_array_1d___raises_value_error(
-    start_index: SupportsIndex, sample_count: SupportsIndex | None, expected_message: str
+def test___invalid_array_subset___from_array_1d___raises_correct_error(
+    start_index: SupportsIndex,
+    sample_count: SupportsIndex | None,
+    expected_message: str,
+    exception_type: type,
 ) -> None:
     data = np.array([1, 2, 3, 4, 5], np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(exception_type) as exc:
         _ = Spectrum.from_array_1d(data, start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -549,36 +560,47 @@ def test___array_subset___from_array_2d___creates_spectrum_with_array_subset(
 
 
 @pytest.mark.parametrize(
-    "start_index, sample_count, expected_message",
+    "start_index, sample_count, expected_message, exception_type",
     [
-        (-2, None, "The start index must be a non-negative integer."),
-        (-1, None, "The start index must be a non-negative integer."),
-        (6, None, "The start index must be less than or equal to the input array length."),
-        (0, -2, "The sample count must be a non-negative integer."),
-        (0, -1, "The sample count must be a non-negative integer."),
+        (-2, None, "The start index must be a non-negative integer.", ValueError),
+        (-1, None, "The start index must be a non-negative integer.", ValueError),
+        (
+            6,
+            None,
+            "The start index must be less than or equal to the input array length.",
+            wfmex.StartIndexTooLargeError,
+        ),
+        (0, -2, "The sample count must be a non-negative integer.", ValueError),
+        (0, -1, "The sample count must be a non-negative integer.", ValueError),
         (
             0,
             6,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             1,
             5,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
         (
             5,
             1,
             "The sum of the start index and sample count must be less than or equal to the input array length.",
+            wfmex.StartIndexOrSampleCountTooLargeError,
         ),
     ],
 )
-def test___invalid_array_subset___from_array_2d___raises_value_error(
-    start_index: SupportsIndex, sample_count: SupportsIndex | None, expected_message: str
+def test___invalid_array_subset___from_array_2d___raises_correct_error(
+    start_index: SupportsIndex,
+    sample_count: SupportsIndex | None,
+    expected_message: str,
+    exception_type: type,
 ) -> None:
     data = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises(exception_type) as exc:
         _ = Spectrum.from_array_2d(data, start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -663,7 +685,9 @@ def test___invalid_array_subset___get_data___returns_array_subset(
 ) -> None:
     spectrum = Spectrum.from_array_1d([0, 1, 2, 3], np.int32)
 
-    with pytest.raises((TypeError, ValueError)) as exc:
+    with pytest.raises(
+        (wfmex.StartIndexTooLargeError, wfmex.StartIndexOrSampleCountTooLargeError)
+    ) as exc:
         _ = spectrum.get_data(start_index=start_index, sample_count=sample_count)
 
     assert exc.value.args[0].startswith(expected_message)
@@ -690,21 +714,29 @@ def test___spectrum___set_capacity___resizes_array_and_pads_with_zeros(
 
 
 @pytest.mark.parametrize(
-    "capacity, expected_message",
+    "capacity, expected_message, exception_type",
     [
-        (-2, "The capacity must be a non-negative integer."),
-        (-1, "The capacity must be a non-negative integer."),
-        (0, "The capacity must be equal to or greater than the number of samples in the spectrum."),
-        (2, "The capacity must be equal to or greater than the number of samples in the spectrum."),
+        (-2, "The capacity must be a non-negative integer.", ValueError),
+        (-1, "The capacity must be a non-negative integer.", ValueError),
+        (
+            0,
+            "The capacity must be equal to or greater than the number of samples in the spectrum.",
+            wfmex.CapacityTooSmallError,
+        ),
+        (
+            2,
+            "The capacity must be equal to or greater than the number of samples in the spectrum.",
+            wfmex.CapacityTooSmallError,
+        ),
     ],
 )
-def test___invalid_capacity___set_capacity___raises_value_error(
-    capacity: int, expected_message: str
+def test___invalid_capacity___set_capacity___raises_correct_error(
+    capacity: int, expected_message: str, exception_type: type
 ) -> None:
     data = [1, 2, 3]
     spectrum = Spectrum.from_array_1d(data, np.int32)
 
-    with pytest.raises((wfmex.CapacityTooSmallError, ValueError)) as exc:
+    with pytest.raises((exception_type)) as exc:
         spectrum.capacity = capacity
 
     assert exc.value.args[0].startswith(expected_message)
@@ -844,7 +876,7 @@ def test___float64_ndarray___append___appends_array() -> None:
     assert list(spectrum.data) == [0, 1, 2, 3, 4, 5]
 
 
-def test___ndarray_with_mismatched_dtype___append___raises_type_error() -> None:
+def test___ndarray_with_mismatched_dtype___append___raises_correct_error() -> None:
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 
@@ -896,7 +928,7 @@ def test___float64_spectrum___append___appends_spectrum() -> None:
     assert list(spectrum.data) == [0, 1, 2, 3, 4, 5]
 
 
-def test___spectrum_with_mismatched_dtype___append___raises_type_error() -> None:
+def test___spectrum_with_mismatched_dtype___append___raises_correct_error() -> None:
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
     other = Spectrum.from_array_1d([3, 4, 5], np.int32)
 
@@ -945,7 +977,7 @@ def test___float64_spectrum_tuple___append___appends_spectrum() -> None:
     assert list(spectrum.data) == [0, 1, 2, 3, 4, 5, 6, 7, 8]
 
 
-def test___spectrum_list_with_mismatched_dtype___append___raises_type_error_and_does_not_append() -> (
+def test___spectrum_list_with_mismatched_dtype___append___raises_correct_error_and_does_not_append() -> (
     None
 ):
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
@@ -993,7 +1025,7 @@ def test___float64_ndarray___load_data___overwrites_data() -> None:
     assert list(spectrum.data) == [3, 4, 5]
 
 
-def test___ndarray_with_mismatched_dtype___load_data___raises_type_error() -> None:
+def test___ndarray_with_mismatched_dtype___load_data___raises_correct_error() -> None:
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -322,7 +322,7 @@ def test___invalid_array_subset___from_array_1d___raises_correct_error(
     start_index: SupportsIndex,
     sample_count: SupportsIndex | None,
     expected_message: str,
-    exception_type: type,
+    exception_type: type[Exception],
 ) -> None:
     data = np.array([1, 2, 3, 4, 5], np.int32)
 
@@ -596,7 +596,7 @@ def test___invalid_array_subset___from_array_2d___raises_correct_error(
     start_index: SupportsIndex,
     sample_count: SupportsIndex | None,
     expected_message: str,
-    exception_type: type,
+    exception_type: type[Exception],
 ) -> None:
     data = np.array([[1, 2, 3, 4, 5], [6, 7, 8, 9, 10]], np.int32)
 
@@ -731,7 +731,7 @@ def test___spectrum___set_capacity___resizes_array_and_pads_with_zeros(
     ],
 )
 def test___invalid_capacity___set_capacity___raises_correct_error(
-    capacity: int, expected_message: str, exception_type: type
+    capacity: int, expected_message: str, exception_type: type[Exception]
 ) -> None:
     data = [1, 2, 3]
     spectrum = Spectrum.from_array_1d(data, np.int32)

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -704,7 +704,7 @@ def test___invalid_capacity___set_capacity___raises_value_error(
     data = [1, 2, 3]
     spectrum = Spectrum.from_array_1d(data, np.int32)
 
-    with pytest.raises(ValueError) as exc:
+    with pytest.raises((wfmex.CapacityTooSmallError, ValueError)) as exc:
         spectrum.capacity = capacity
 
     assert exc.value.args[0].startswith(expected_message)
@@ -848,7 +848,7 @@ def test___ndarray_with_mismatched_dtype___append___raises_type_error() -> None:
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
     array = np.array([3, 4, 5], np.int32)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         spectrum.append(array)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -900,7 +900,7 @@ def test___spectrum_with_mismatched_dtype___append___raises_type_error() -> None
     spectrum = Spectrum.from_array_1d([0, 1, 2], np.float64)
     other = Spectrum.from_array_1d([3, 4, 5], np.int32)
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         spectrum.append(other)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(
@@ -954,7 +954,7 @@ def test___spectrum_list_with_mismatched_dtype___append___raises_type_error_and_
         Spectrum.from_array_1d([6, 7, 8], np.int32),
     ]
 
-    with pytest.raises(TypeError) as exc:
+    with pytest.raises(wfmex.DatatypeMismatchError) as exc:
         spectrum.append(other)  # type: ignore[arg-type]
 
     assert exc.value.args[0].startswith(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Create a public exception class for each current waveform exception method that extends the exception type it raised previously (`TypeError`, `ValueError`, etc.).
- Change the waveform exception methods so that they raise the associated exception class after building an error string.
- Update call sites to use the new method names (add `raise_` to the front).
- Update unit tests to check for the more specific exception classes.
- Non-test code that checks for `ValueError` or `TypeError` has been left unchanged since those statements will still be correct due to inheritance.

### Why should this Pull Request be merged?

[AB#3153442](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3153442)

### What testing has been done?

Unit tests, mypy, styleguide, pyright.

### Old notes from RFC phase (see comments for discussion/answers)

I'm not sure if it should be merged. I'm putting this up to show what it would look like if we switched to classes.

Note that there are a bunch of test failures for tests that assumed `TypeError` or `ValueError` would be thrown. We'd have to clean all those up.

Also note that there is some code that catches `TypeError` and `ValueError` and adds notes to them. We'd have to update those `except` statements as well.

Opinion: We don't get a ton of benefit from this PR other than being "more correct" by directly raising an exception instead of an exception returned from a method. Even that "more correct" judgement is pretty subjective. I guess we also get explicit exception types that clients can put in `except` statements. But since each exception is so niche, it doesn't seem like clients would want to do that.
