### PR TITLE
Add digital states 8-11.

### DIFF
--- a/src/nitypes/waveform/_digital/_state.py
+++ b/src/nitypes/waveform/_digital/_state.py
@@ -4,18 +4,22 @@ from enum import IntEnum
 
 from nitypes._exceptions import invalid_arg_value
 
-_CHAR_TABLE = "01ZLHXTV"
+_CHAR_TABLE = ["0", "1", "Z", "L", "H", "X", "T", "V", "0L", "1H", "N01", "N01LH"]
 
 _STATE_TEST_TABLE = [
-    # 0  1  Z  L  H  X  T  V
-    [1, 0, 0, 1, 0, 1, 0, 1],  # 0
-    [0, 1, 0, 0, 1, 1, 0, 1],  # 1
-    [0, 0, 1, 0, 0, 1, 1, 0],  # Z
-    [1, 0, 0, 1, 0, 1, 0, 0],  # L
-    [0, 1, 0, 0, 1, 1, 0, 0],  # H
-    [1, 1, 1, 1, 1, 1, 1, 1],  # X
-    [0, 0, 1, 0, 0, 1, 1, 0],  # T
-    [1, 1, 0, 0, 0, 1, 0, 1],  # V
+    # 0  1  Z  L  H  X  T  V 0L 1H N01 N01LH
+    [1, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0],  # 0
+    [0, 1, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0],  # 1
+    [0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1],  # Z
+    [1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0],  # L
+    [0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 1, 0],  # H
+    [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1],  # X
+    [0, 0, 1, 0, 0, 1, 1, 0, 0, 0, 0, 0],  # T
+    [1, 1, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0],  # V
+    [1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0],  # 0L
+    [0, 1, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0],  # 1H
+    [0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 1, 0],  # N01
+    [0, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 1],  # N01LH
 ]
 
 
@@ -73,6 +77,22 @@ class DigitalState(IntEnum):
     COMPARE_VALID = 7
     """Compare logic valid level (edge) (``V``). Compare for a voltage level either lower than the
     low voltage threshold (VOL) or higher than the high voltage threshold (VOH)."""
+
+    EQUAL_0_L = 8
+    """Compare logic equal to 0 or Low (edge) (``0L``). Compare for a voltage level equal to 0 or
+    Low."""
+
+    EQUAL_1_H = 9
+    """Compare logic equal to 1 or High (edge) (``1H``). Compare for a voltage level equal to 1 or
+    High."""
+
+    NOT_EQUAL_0_1 = 10
+    """Compare logic not equal to 0 or 1 (edge) (``N01``). Compare for a voltage level not equal
+    to 0 or 1."""
+
+    NOT_EQUAL_0_1_L_H = 11
+    """Compare logic not equal to 0, 1, Low, or High (edge) (``N01LH``). Compare for a voltage
+    level not equal to 0, 1, Low, or High."""
 
     @property
     def char(self) -> str:

--- a/tests/unit/waveform/test_digital_state.py
+++ b/tests/unit/waveform/test_digital_state.py
@@ -11,13 +11,15 @@ from nitypes.waveform import DigitalState
         (DigitalState.FORCE_DOWN, "0"),
         (DigitalState.COMPARE_HIGH, "H"),
         (DigitalState.COMPARE_UNKNOWN, "X"),
+        (DigitalState.EQUAL_1_H, "1H"),
+        (DigitalState.NOT_EQUAL_0_1_L_H, "N01LH"),
     ],
 )
 def test___state___to_char___returns_char(state: DigitalState, expected_char: str) -> None:
     assert DigitalState.to_char(state) == expected_char
 
 
-@pytest.mark.parametrize("state", [-1, 8, 255])
+@pytest.mark.parametrize("state", [-1, 12, 255])
 def test___invalid_state___to_char___raises_key_error(state: DigitalState) -> None:
     with pytest.raises(KeyError) as exc:
         _ = DigitalState.to_char(state)
@@ -25,7 +27,7 @@ def test___invalid_state___to_char___raises_key_error(state: DigitalState) -> No
     assert exc.value.args[0] == state
 
 
-@pytest.mark.parametrize("state", [-1, 8, 255])
+@pytest.mark.parametrize("state", [-1, 12, 255])
 def test___invalid_state_errors_replace___to_char___returns_question_mark(
     state: DigitalState,
 ) -> None:
@@ -38,6 +40,8 @@ def test___invalid_state_errors_replace___to_char___returns_question_mark(
         ("0", DigitalState.FORCE_DOWN),
         ("H", DigitalState.COMPARE_HIGH),
         ("X", DigitalState.COMPARE_UNKNOWN),
+        ("1H", DigitalState.EQUAL_1_H),
+        ("N01LH", DigitalState.NOT_EQUAL_0_1_L_H),
     ],
 )
 def test___char___from_char___returns_state(char: str, expected_state: DigitalState) -> None:
@@ -65,6 +69,11 @@ def test___invalid_char___from_char___raises_key_error(char: str) -> None:
         ("1", "X", False),
         ("0", "X", False),
         ("H", "L", True),
+        ("H", "1H", False),
+        ("0", "0L", False),
+        ("H", "0L", True),
+        ("H", "N01", False),
+        ("Z", "N01LH", False),
     ],
 )
 def test___states___test___returns_pass_fail(char1: str, char2: str, expected_result: bool) -> None:
@@ -79,7 +88,7 @@ def test___states___test___returns_pass_fail(char1: str, char2: str, expected_re
     "state1, state2",
     [
         (DigitalState.FORCE_DOWN, -1),
-        (8, DigitalState.COMPARE_UNKNOWN),
+        (12, DigitalState.COMPARE_UNKNOWN),
     ],
 )
 def test___invalid_state___test___raises_value_error(

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -134,6 +134,10 @@ def test___dtype_str_with_tdata_hint___create___narrows_tdata() -> None:
         DigitalState.FORCE_DOWN,
         DigitalState.FORCE_UP,
         DigitalState.COMPARE_VALID,
+        DigitalState.EQUAL_0_L,
+        DigitalState.EQUAL_1_H,
+        DigitalState.NOT_EQUAL_0_1,
+        DigitalState.NOT_EQUAL_0_1_L_H,
     ],
 )
 def test___default_value___create___creates_waveform_with_default_value(


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds digital states 8-11 to the `DigitalState` enum and state table. Also updates tests to include these new states.

### Why should this Pull Request be merged?

Completes [AB#3178779](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3178779)

### What testing has been done?

Unit tests, mypy, styleguide.
