### PR TITLE
Remove fixed xfails

### DIFF
--- a/tests/unit/bintime/test_datetime.py
+++ b/tests/unit/bintime/test_datetime.py
@@ -326,10 +326,9 @@ def test___datetime___sub___returns_time_value(
             DateTime(2025, 1, 1, tzinfo=dt.timezone.utc),
             ht.datetime(2025, 1, 1, tzinfo=dt.timezone.utc),
         ),
-        pytest.param(
+        (
             ht.datetime(2025, 1, 1, tzinfo=dt.timezone.utc),
             DateTime(2025, 1, 1, tzinfo=dt.timezone.utc),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
         ),
     ],
 )
@@ -371,20 +370,17 @@ def test___same_value___comparison___equal(
             DateTime(2025, 1, 1, tzinfo=dt.timezone.utc),
             ht.datetime(2025, 1, 1, yoctosecond=1, tzinfo=dt.timezone.utc),
         ),
-        pytest.param(
+        (
             ht.datetime(2025, 1, 1, tzinfo=dt.timezone.utc),
             DateTime(2025, 1, 2, tzinfo=dt.timezone.utc),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
         ),
-        pytest.param(
+        (
             ht.datetime(2025, 1, 1, tzinfo=dt.timezone.utc) - ht.timedelta(femtoseconds=1),
             DateTime(2025, 1, 2, tzinfo=dt.timezone.utc),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
         ),
-        pytest.param(
+        (
             ht.datetime(2025, 1, 1, tzinfo=dt.timezone.utc) - ht.timedelta(yoctoseconds=1),
             DateTime(2025, 1, 1, tzinfo=dt.timezone.utc),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
         ),
     ],
 )

--- a/tests/unit/bintime/test_timedelta.py
+++ b/tests/unit/bintime/test_timedelta.py
@@ -1074,11 +1074,7 @@ def test___ht_timedelta___divmod___returns_int_and_timedelta(
         (TimeDelta(1), dt.timedelta(seconds=1)),
         (TimeDelta(1), ht.timedelta(seconds=1)),
         (dt.timedelta(seconds=1), TimeDelta(1)),
-        pytest.param(
-            ht.timedelta(seconds=1),
-            TimeDelta(1),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
-        ),
+        (ht.timedelta(seconds=1), TimeDelta(1)),
     ],
 )
 def test___same_value___comparison___equal(
@@ -1111,21 +1107,9 @@ def test___same_value___comparison___equal(
         (TimeDelta(1), ht.timedelta(seconds=1, femtoseconds=1)),
         (TimeDelta(1), ht.timedelta(seconds=1, yoctoseconds=1)),
         (dt.timedelta(seconds=1), TimeDelta(2)),
-        pytest.param(
-            ht.timedelta(seconds=1),
-            TimeDelta(2),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
-        ),
-        pytest.param(
-            ht.timedelta(seconds=1) - ht.timedelta(femtoseconds=1),
-            TimeDelta(1),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
-        ),
-        pytest.param(
-            ht.timedelta(seconds=1) - ht.timedelta(yoctoseconds=1),
-            TimeDelta(1),
-            marks=pytest.mark.xfail(reason="https://github.com/ni/hightime/issues/60"),
-        ),
+        (ht.timedelta(seconds=1), TimeDelta(2)),
+        (ht.timedelta(seconds=1) - ht.timedelta(femtoseconds=1), TimeDelta(1)),
+        (ht.timedelta(seconds=1) - ht.timedelta(yoctoseconds=1), TimeDelta(1)),
     ],
 )
 def test___lesser_value___comparison___lesser(

--- a/tests/unit/time/test_conversion.py
+++ b/tests/unit/time/test_conversion.py
@@ -47,7 +47,7 @@ def test___ht_to_ht___convert_datetime___returns_original_object() -> None:
     assert value_out is value_in
 
 
-def test___bt_to_dt___convert_datetime___returns_equivalant_dt_datetime() -> None:
+def test___bt_to_dt___convert_datetime___returns_equivalent_dt_datetime() -> None:
     value_in = bt.DateTime.now(dt.timezone.utc)
 
     value_out = convert_datetime(dt.datetime, value_in)
@@ -59,7 +59,7 @@ def test___bt_to_dt___convert_datetime___returns_equivalant_dt_datetime() -> Non
     assert value_out.fold == 0
 
 
-def test___bt_to_ht___convert_datetime___returns_equivalant_ht_datetime() -> None:
+def test___bt_to_ht___convert_datetime___returns_equivalent_ht_datetime() -> None:
     value_in = bt.DateTime.now(dt.timezone.utc)
 
     value_out = convert_datetime(ht.datetime, value_in)
@@ -71,7 +71,7 @@ def test___bt_to_ht___convert_datetime___returns_equivalant_ht_datetime() -> Non
     assert value_out.fold == 0
 
 
-def test___dt_to_bt___convert_datetime___returns_equivalant_bt_datetime() -> None:
+def test___dt_to_bt___convert_datetime___returns_equivalent_bt_datetime() -> None:
     value_in = dt.datetime.now(dt.timezone.utc)
 
     value_out = convert_datetime(bt.DateTime, value_in)
@@ -82,7 +82,7 @@ def test___dt_to_bt___convert_datetime___returns_equivalant_bt_datetime() -> Non
     assert value_out.tzinfo is value_in.tzinfo
 
 
-def test___dt_to_ht___convert_datetime___returns_equivalant_ht_datetime() -> None:
+def test___dt_to_ht___convert_datetime___returns_equivalent_ht_datetime() -> None:
     value_in = dt.datetime.now(dt.timezone.utc)
 
     value_out = convert_datetime(ht.datetime, value_in)
@@ -94,7 +94,7 @@ def test___dt_to_ht___convert_datetime___returns_equivalant_ht_datetime() -> Non
     assert value_out.fold == value_in.fold
 
 
-def test___ht_to_bt___convert_datetime___returns_equivalant_bt_datetime() -> None:
+def test___ht_to_bt___convert_datetime___returns_equivalent_bt_datetime() -> None:
     value_in = ht.datetime.now(dt.timezone.utc)
 
     value_out = convert_datetime(bt.DateTime, value_in)
@@ -105,7 +105,7 @@ def test___ht_to_bt___convert_datetime___returns_equivalant_bt_datetime() -> Non
     assert value_out.tzinfo is value_in.tzinfo
 
 
-def test___ht_to_dt___convert_datetime___returns_equivalant_dt_datetime() -> None:
+def test___ht_to_dt___convert_datetime___returns_equivalent_dt_datetime() -> None:
     value_in = ht.datetime.now(dt.timezone.utc)
 
     value_out = convert_datetime(dt.datetime, value_in)
@@ -208,7 +208,7 @@ def test___ht_to_ht___convert_timedelta___returns_original_object() -> None:
     assert value_out is value_in
 
 
-def test___bt_to_dt___convert_timedelta___returns_equivalant_dt_timedelta() -> None:
+def test___bt_to_dt___convert_timedelta___returns_equivalent_dt_timedelta() -> None:
     # 1 << 124 ticks is 1 << 60 seconds, which is too big for dt.timedelta.
     value_in = bt.TimeDelta.from_ticks((1 << 92) + (2 << 64) + 3)
 
@@ -219,7 +219,7 @@ def test___bt_to_dt___convert_timedelta___returns_equivalant_dt_timedelta() -> N
     assert abs(value_out - value_in) <= _DT_EPSILON
 
 
-def test___bt_to_ht___convert_timedelta___returns_equivalant_ht_timedelta() -> None:
+def test___bt_to_ht___convert_timedelta___returns_equivalent_ht_timedelta() -> None:
     # 1 << 124 ticks is 1 << 60 seconds, which is too big for ht.timedelta too, apparently.
     value_in = bt.TimeDelta.from_ticks((1 << 92) + (2 << 64) + 3)
 
@@ -230,7 +230,7 @@ def test___bt_to_ht___convert_timedelta___returns_equivalant_ht_timedelta() -> N
     assert abs(value_out - value_in) <= _BT_EPSILON
 
 
-def test___dt_to_bt___convert_timedelta___returns_equivalant_bt_timedelta() -> None:
+def test___dt_to_bt___convert_timedelta___returns_equivalent_bt_timedelta() -> None:
     value_in = dt.timedelta(days=1, seconds=2, microseconds=3)
 
     value_out = convert_timedelta(bt.TimeDelta, value_in)
@@ -240,7 +240,7 @@ def test___dt_to_bt___convert_timedelta___returns_equivalant_bt_timedelta() -> N
     assert abs(value_out - value_in) <= _BT_EPSILON
 
 
-def test___dt_to_ht___convert_timedelta___returns_equivalant_ht_timedelta() -> None:
+def test___dt_to_ht___convert_timedelta___returns_equivalent_ht_timedelta() -> None:
     value_in = dt.timedelta(days=1, seconds=2, microseconds=3)
 
     value_out = convert_timedelta(ht.timedelta, value_in)
@@ -250,7 +250,7 @@ def test___dt_to_ht___convert_timedelta___returns_equivalant_ht_timedelta() -> N
     assert value_out == value_in
 
 
-def test___ht_to_bt___convert_timedelta___returns_equivalant_bt_timedelta() -> None:
+def test___ht_to_bt___convert_timedelta___returns_equivalent_bt_timedelta() -> None:
     value_in = ht.timedelta(days=1, seconds=2, microseconds=3)
 
     value_out = convert_timedelta(bt.TimeDelta, value_in)
@@ -260,7 +260,7 @@ def test___ht_to_bt___convert_timedelta___returns_equivalant_bt_timedelta() -> N
     assert abs(value_out - value_in) <= _BT_EPSILON
 
 
-def test___ht_to_dt___convert_timedelta___returns_equivalant_dt_timedelta() -> None:
+def test___ht_to_dt___convert_timedelta___returns_equivalent_dt_timedelta() -> None:
     value_in = ht.timedelta(days=1, seconds=2, microseconds=3)
 
     value_out = convert_timedelta(dt.timedelta, value_in)

--- a/tests/unit/time/test_conversion.py
+++ b/tests/unit/time/test_conversion.py
@@ -13,9 +13,6 @@ from nitypes.time import convert_datetime, convert_timedelta
 _BT_EPSILON = ht.timedelta(yoctoseconds=54210)
 _DT_EPSILON = ht.timedelta(microseconds=1)
 
-# Work around https://github.com/ni/hightime/issues/60
-_DT_EPSILON_AS_BT = bt.TimeDelta(1e-6)
-
 
 ###############################################################################
 # convert_datetime
@@ -54,7 +51,7 @@ def test___bt_to_dt___convert_datetime___returns_equivalent_dt_datetime() -> Non
 
     assert_type(value_out, dt.datetime)
     assert isinstance(value_out, dt.datetime)
-    assert abs(value_out - value_in) <= _DT_EPSILON_AS_BT
+    assert abs(value_out - value_in) <= _DT_EPSILON
     assert value_out.tzinfo is value_in.tzinfo
     assert value_out.fold == 0
 

--- a/tests/unit/time/test_conversion.py
+++ b/tests/unit/time/test_conversion.py
@@ -237,7 +237,7 @@ def test___dt_to_bt___convert_timedelta___returns_equivalant_bt_timedelta() -> N
 
     assert_type(value_out, bt.TimeDelta)
     assert isinstance(value_out, bt.TimeDelta)
-    assert abs(value_out - value_in) <= _DT_EPSILON
+    assert abs(value_out - value_in) <= _BT_EPSILON
 
 
 def test___dt_to_ht___convert_timedelta___returns_equivalant_ht_timedelta() -> None:

--- a/tests/unit/time/test_conversion.py
+++ b/tests/unit/time/test_conversion.py
@@ -51,7 +51,7 @@ def test___bt_to_dt___convert_datetime___returns_equivalent_dt_datetime() -> Non
 
     assert_type(value_out, dt.datetime)
     assert isinstance(value_out, dt.datetime)
-    assert abs(value_out - value_in) <= _DT_EPSILON
+    assert abs(value_out - value_in) <= _DT_EPSILON + _BT_EPSILON
     assert value_out.tzinfo is value_in.tzinfo
     assert value_out.fold == 0
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Removes the `xfail` markers on the tests
  - Dependency on `hightime` is at v0.3.0-dev1 which has a fix for its issue 60
- Fixes a test logic typo
- Fixes spelling for test names

### Why should this Pull Request be merged?

- Keep up with dependencies

### What testing has been done?

- PR checks
