### PR TITLE
Add setter for sample_count property

### DIFF
--- a/src/nitypes/waveform/_analog.py
+++ b/src/nitypes/waveform/_analog.py
@@ -482,7 +482,6 @@ class AnalogWaveform(NumericWaveform[_TRaw, np.float64]):
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
             start_index: The sample index at which the analog waveform data begins.
-            sample_count: The number of samples in the analog waveform.
             capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
                 appending samples to the waveform.
             extended_properties: The extended properties of the analog waveform.

--- a/src/nitypes/waveform/_complex.py
+++ b/src/nitypes/waveform/_complex.py
@@ -386,7 +386,6 @@ class ComplexWaveform(NumericWaveform[_TRaw, np.complex128]):
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
             start_index: The sample index at which the waveform data begins.
-            sample_count: The number of samples in the waveform.
             capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
                 appending samples to the waveform.
             extended_properties: The extended properties of the waveform.

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -240,7 +240,6 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
             start_index: The sample index at which the waveform data begins.
-            sample_count: The number of samples in the waveform.
             capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
                 appending samples to the waveform.
             extended_properties: The extended properties of the waveform.
@@ -514,14 +513,14 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         self._extended_properties[CHANNEL_NAME] = value
 
     @property
-    def unit_description(self) -> str:
+    def units(self) -> str:
         """The unit of measurement, such as volts, of the waveform."""
         value = self._extended_properties.get(UNIT_DESCRIPTION, "")
         assert isinstance(value, str)
         return value
 
-    @unit_description.setter
-    def unit_description(self, value: str) -> None:
+    @units.setter
+    def units(self, value: str) -> None:
         if not isinstance(value, str):
             raise invalid_arg_type("unit description", "str", value)
         self._extended_properties[UNIT_DESCRIPTION] = value

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -456,6 +456,14 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         """The number of samples in the waveform."""
         return self._sample_count
 
+    @sample_count.setter
+    def sample_count(self, value: int) -> None:
+        """Set the number of samples in the waveform."""
+        value = arg_to_uint("sample count", value)
+        if value <= 0:
+            raise ValueError("Sample count must be greater than zero.")
+        self._sample_count = value
+
     @property
     def capacity(self) -> int:
         """The total capacity available for waveform data.

--- a/src/nitypes/waveform/_spectrum.py
+++ b/src/nitypes/waveform/_spectrum.py
@@ -403,7 +403,6 @@ class Spectrum(Generic[_TData]):
                 of this array. If not specified, an ndarray is created based on the specified dtype,
                 start index, sample count, and capacity.
             start_index: The sample index at which the spectrum data begins.
-            sample_count: The number of samples in the spectrum.
             capacity: The number of samples to allocate. Pre-allocating a larger buffer optimizes
                 appending samples to the spectrum.
             start_frequency: The start frequency of the spectrum.
@@ -609,14 +608,14 @@ class Spectrum(Generic[_TData]):
         self._extended_properties[CHANNEL_NAME] = value
 
     @property
-    def unit_description(self) -> str:
+    def units(self) -> str:
         """The unit of measurement, such as volts, of the spectrum."""
         value = self._extended_properties.get(UNIT_DESCRIPTION, "")
         assert isinstance(value, str)
         return value
 
-    @unit_description.setter
-    def unit_description(self, value: str) -> None:
+    @units.setter
+    def units(self, value: str) -> None:
         if not isinstance(value, str):
             raise invalid_arg_type("unit description", "str", value)
         self._extended_properties[UNIT_DESCRIPTION] = value

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -944,20 +944,20 @@ def test___invalid_type___set_channel_name___raises_type_error() -> None:
     assert exc.value.args[0].startswith("The channel name must be a str.")
 
 
-def test___waveform___set_unit_description___sets_extended_property() -> None:
+def test___waveform___set_units___sets_extended_property() -> None:
     waveform = AnalogWaveform()
 
-    waveform.unit_description = "Volts"
+    waveform.units = "Volts"
 
-    assert waveform.unit_description == "Volts"
+    assert waveform.units == "Volts"
     assert waveform.extended_properties["NI_UnitDescription"] == "Volts"
 
 
-def test___invalid_type___set_unit_description___raises_type_error() -> None:
+def test___invalid_type___set_units___raises_type_error() -> None:
     waveform = AnalogWaveform()
 
     with pytest.raises(TypeError) as exc:
-        waveform.unit_description = None  # type: ignore[assignment]
+        waveform.units = None  # type: ignore[assignment]
 
     assert exc.value.args[0].startswith("The unit description must be a str.")
 

--- a/tests/unit/waveform/test_spectrum.py
+++ b/tests/unit/waveform/test_spectrum.py
@@ -786,20 +786,20 @@ def test___invalid_type___set_channel_name___raises_type_error() -> None:
     assert exc.value.args[0].startswith("The channel name must be a str.")
 
 
-def test___spectrum___set_unit_description___sets_extended_property() -> None:
+def test___spectrum___set_units___sets_extended_property() -> None:
     spectrum = Spectrum()
 
-    spectrum.unit_description = "Volts"
+    spectrum.units = "Volts"
 
-    assert spectrum.unit_description == "Volts"
+    assert spectrum.units == "Volts"
     assert spectrum.extended_properties["NI_UnitDescription"] == "Volts"
 
 
-def test___invalid_type___set_unit_description___raises_type_error() -> None:
+def test___invalid_type___set_units___raises_type_error() -> None:
     spectrum = Spectrum()
 
     with pytest.raises(TypeError) as exc:
-        spectrum.unit_description = None  # type: ignore[assignment]
+        spectrum.units = None  # type: ignore[assignment]
 
     assert exc.value.args[0].startswith("The unit description must be a str.")
 


### PR DESCRIPTION
- [] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds a setter for the sample count property for waveforms
- Renames unit_description to units for consistency
- Removed duplicate sample_count documentation 

### Why should this Pull Request be merged?

AB#
Fixes #168 

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
