### PR TITLE
Remove int range checking from Scalar constructor

### DIFF
--- a/src/nitypes/scalar.py
+++ b/src/nitypes/scalar.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Generic, Union
 
 from typing_extensions import TypeVar, final
 
-from nitypes._exceptions import invalid_arg_type, invalid_arg_value
+from nitypes._exceptions import invalid_arg_type
 from nitypes.waveform._extended_properties import UNIT_DESCRIPTION
 
 if TYPE_CHECKING:
@@ -75,11 +75,6 @@ class Scalar(Generic[TScalar_co]):
 
         if not isinstance(units, str):
             raise invalid_arg_type("units", "str", units)
-
-        # The ScalarData proto type only supports 32 bit integers. Make sure we're in range.
-        if isinstance(value, int):
-            if value <= -0x80000000 or value >= 0x7FFFFFFF:
-                raise invalid_arg_value("integer scalar value", "within the range of Int32", value)
 
         self._value = value
         self._extended_properties = ExtendedPropertyDictionary()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Removes the `int` range checking code in `Scalar.__init__()`. This range checking is already done when converting a `Scalar` to a protobuf message since the protobuf message is what needs to limit the integer to 32 bits.

### Why should this Pull Request be merged?

Fix #170 
Fix [AB#3227866](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3227866)

### What testing has been done?

Unit tests, mypy, pyright, styleguide
