### PR TITLE
Remove min_rounds=100 from array benchmark tests

### DIFF
--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -23,7 +23,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="datetime_array_construct", warmup=False)
+@pytest.mark.benchmark(group="datetime_array_construct", warmup="off")
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -32,7 +32,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend")
+@pytest.mark.benchmark(group="datetime_array_extend", warmup="off")
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
+import sys
+from typing import Any
+
 import numpy as np
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 import nitypes.bintime as bt
+
+
+benchmark_options: dict[str, Any] = {}
+match sys.implementation.name:
+    case "pypy":
+        # See #182 -- PR/CI workflows spend too much time on PyPy benchmarks
+        benchmark_options["warmup"] = False
+        benchmark_options["min_rounds"] = 1
+        benchmark_options["max_time"] = 0.5
+    case _:
+        pass
 
 
 LIST_1 = [bt.DateTime.from_offset(bt.TimeDelta(0.3))]
@@ -19,11 +33,11 @@ LIST_10000 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
 ]
 
-FAST_CASES = (LIST_1, LIST_10, LIST_100)
+FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="datetime_array_construct")
+@pytest.mark.benchmark(group="datetime_array_construct", **benchmark_options)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -32,7 +46,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend")
+@pytest.mark.benchmark(group="datetime_array_extend", **benchmark_options)
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -10,15 +10,15 @@ import nitypes.bintime as bt
 LIST_10: list[bt.DateTime] = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)
 ]
-# LIST_100: list[bt.DateTime] = [
-#     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 100, 0.3)
-# ]
-# LIST_1000: list[bt.DateTime] = [
-#     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 1000, 0.3)
-# ]
-# LIST_10000: list[bt.DateTime] = [
-#     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
-# ]
+LIST_100: list[bt.DateTime] = [
+    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 100, 0.3)
+]
+LIST_1000: list[bt.DateTime] = [
+    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 1000, 0.3)
+]
+LIST_10000: list[bt.DateTime] = [
+    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
+]
 
 
 @pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1, max_time=0.5)

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -21,7 +21,7 @@ LIST_10000: list[bt.DateTime] = [
 ]
 
 
-@pytest.mark.benchmark(group="datetime_array_construct", min_rounds=100)
+@pytest.mark.benchmark(group="datetime_array_construct")
 @pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -30,7 +30,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend", min_rounds=100)
+@pytest.mark.benchmark(group="datetime_array_extend")
 @pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -10,19 +10,19 @@ import nitypes.bintime as bt
 LIST_10: list[bt.DateTime] = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)
 ]
-LIST_100: list[bt.DateTime] = [
-    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 100, 0.3)
-]
-LIST_1000: list[bt.DateTime] = [
-    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 1000, 0.3)
-]
-LIST_10000: list[bt.DateTime] = [
-    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
-]
+# LIST_100: list[bt.DateTime] = [
+#     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 100, 0.3)
+# ]
+# LIST_1000: list[bt.DateTime] = [
+#     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 1000, 0.3)
+# ]
+# LIST_10000: list[bt.DateTime] = [
+#     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
+# ]
 
 
 @pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.parametrize("constructor_list", (LIST_10))
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.DateTime],
@@ -31,7 +31,7 @@ def test___bt_datetime_array___construct(
 
 
 @pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.parametrize("extend_list", (LIST_10))
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.DateTime],

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -19,7 +19,7 @@ LIST_10000 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
 ]
 
-FAST_CASES = (LIST_1,)
+FAST_CASES = (LIST_1, LIST_10, LIST_100)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -7,17 +7,15 @@ from pytest_benchmark.fixture import BenchmarkFixture
 import nitypes.bintime as bt
 
 
-LIST_1: list[bt.DateTime] = [bt.DateTime.from_offset(bt.TimeDelta(0.3))]
-LIST_10: list[bt.DateTime] = [
-    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)
-]
-LIST_100: list[bt.DateTime] = [
+LIST_1 = [bt.DateTime.from_offset(bt.TimeDelta(0.3))]
+LIST_10 = [bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)]
+LIST_100 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 100, 0.3)
 ]
-LIST_1000: list[bt.DateTime] = [
+LIST_1000 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 1000, 0.3)
 ]
-LIST_10000: list[bt.DateTime] = [
+LIST_10000 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
 ]
 

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -23,7 +23,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="datetime_array_construct", warmup="off")
+@pytest.mark.benchmark(group="datetime_array_construct", warmup=False)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -32,7 +32,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend", warmup="off")
+@pytest.mark.benchmark(group="datetime_array_extend", warmup=False)
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -22,7 +22,7 @@ LIST_10: list[bt.DateTime] = [
 
 
 @pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("constructor_list", (LIST_10))
+@pytest.mark.parametrize("constructor_list", (LIST_10,))
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.DateTime],
@@ -31,7 +31,7 @@ def test___bt_datetime_array___construct(
 
 
 @pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_10))
+@pytest.mark.parametrize("extend_list", (LIST_10,))
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.DateTime],

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -21,7 +21,7 @@ LIST_10000: list[bt.DateTime] = [
 ]
 
 
-@pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1)
+@pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1, max_time=0.5)
 @pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -30,7 +30,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1)
+@pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1, max_time=0.5)
 @pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -25,7 +25,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1, max_time=0.5)
+@pytest.mark.benchmark(group="datetime_array_construct")
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -34,7 +34,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1, max_time=0.5)
+@pytest.mark.benchmark(group="datetime_array_extend")
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -7,6 +7,7 @@ from pytest_benchmark.fixture import BenchmarkFixture
 import nitypes.bintime as bt
 
 
+LIST_1: list[bt.DateTime] = [bt.DateTime.from_offset(bt.TimeDelta(0.3))]
 LIST_10: list[bt.DateTime] = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)
 ]
@@ -20,9 +21,12 @@ LIST_10000: list[bt.DateTime] = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
 ]
 
+FAST_CASES = (LIST_1,)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
+
 
 @pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("constructor_list", (LIST_10,))
+@pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.DateTime],
@@ -31,7 +35,7 @@ def test___bt_datetime_array___construct(
 
 
 @pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_10,))
+@pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.DateTime],

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -23,7 +23,7 @@ FAST_CASES = (LIST_1, LIST_10, LIST_100)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="datetime_array_construct", warmup=False)
+@pytest.mark.benchmark(group="datetime_array_construct")
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -32,7 +32,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend", warmup=False)
+@pytest.mark.benchmark(group="datetime_array_extend")
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -23,7 +23,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="datetime_array_construct")
+@pytest.mark.benchmark(group="datetime_array_construct", warmup=False)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -21,7 +21,7 @@ LIST_10000: list[bt.DateTime] = [
 ]
 
 
-@pytest.mark.benchmark(group="datetime_array_construct")
+@pytest.mark.benchmark(group="datetime_array_construct", min_rounds=1)
 @pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -30,7 +30,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend")
+@pytest.mark.benchmark(group="datetime_array_extend", min_rounds=1)
 @pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ LIST_10000: list[bt.TimeDelta] = [
 ]
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct")
+@pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1)
 @pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend")
+@pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1)
 @pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -7,6 +7,7 @@ from pytest_benchmark.fixture import BenchmarkFixture
 import nitypes.bintime as bt
 
 
+LIST_1 = [bt.TimeDelta(0.3)]
 LIST_10: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
 # LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
 # LIST_1000: list[bt.TimeDelta] = [
@@ -27,7 +28,7 @@ def test___bt_timedelta_array___construct(
 
 
 @pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_10,))
+@pytest.mark.parametrize("extend_list", (LIST_1,))
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.TimeDelta],

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -8,14 +8,10 @@ import nitypes.bintime as bt
 
 
 LIST_1 = [bt.TimeDelta(0.3)]
-LIST_10: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
-LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
-LIST_1000: list[bt.TimeDelta] = [
-    bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
-]
-LIST_10000: list[bt.TimeDelta] = [
-    bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)
-]
+LIST_10 = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
+LIST_100 = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
+LIST_1000 = [bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)]
+LIST_10000 = [bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)]
 
 FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -8,17 +8,17 @@ import nitypes.bintime as bt
 
 
 LIST_10: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
-LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
-LIST_1000: list[bt.TimeDelta] = [
-    bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
-]
-LIST_10000: list[bt.TimeDelta] = [
-    bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)
-]
+# LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
+# LIST_1000: list[bt.TimeDelta] = [
+#     bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
+# ]
+# LIST_10000: list[bt.TimeDelta] = [
+#     bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)
+# ]
 
 
 @pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.parametrize("constructor_list", (LIST_10))
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.TimeDelta],
@@ -27,7 +27,7 @@ def test___bt_timedelta_array___construct(
 
 
 @pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.parametrize("extend_list", (LIST_10))
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.TimeDelta],

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ LIST_10000: list[bt.TimeDelta] = [
 ]
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=100)
+@pytest.mark.benchmark(group="timedelta_array_construct")
 @pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=100)
+@pytest.mark.benchmark(group="timedelta_array_extend")
 @pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ FAST_CASES = (LIST_1, LIST_10)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct", warmup=False)
+@pytest.mark.benchmark(group="timedelta_array_construct")
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend", warmup=False)
+@pytest.mark.benchmark(group="timedelta_array_extend")
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -1,10 +1,24 @@
 from __future__ import annotations
 
+import sys
+from typing import Any
+
 import numpy as np
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 import nitypes.bintime as bt
+
+
+benchmark_options: dict[str, Any] = {}
+match sys.implementation.name:
+    case "pypy":
+        # See #182 -- PR/CI workflows spend too much time on PyPy benchmarks
+        benchmark_options["warmup"] = False
+        benchmark_options["min_rounds"] = 1
+        benchmark_options["max_time"] = 0.5
+    case _:
+        pass
 
 
 LIST_1 = [bt.TimeDelta(0.3)]
@@ -14,10 +28,10 @@ LIST_1000 = [bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
 LIST_10000 = [bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)]
 
 FAST_CASES = (LIST_1, LIST_10)
-BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)  # Useful for local measurements
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct")
+@pytest.mark.benchmark(group="timedelta_array_construct", **benchmark_options)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +40,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend")
+@pytest.mark.benchmark(group="timedelta_array_extend", **benchmark_options)
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -13,7 +13,7 @@ LIST_100 = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
 LIST_1000 = [bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)]
 LIST_10000 = [bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)]
 
-FAST_CASES = (LIST_1,)
+FAST_CASES = (LIST_1, LIST_10)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1, max_time=0.5)
+@pytest.mark.benchmark(group="timedelta_array_construct")
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1, max_time=0.5)
+@pytest.mark.benchmark(group="timedelta_array_extend")
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct", warmup="off")
+@pytest.mark.benchmark(group="timedelta_array_construct", warmup=False)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend", warmup="off")
+@pytest.mark.benchmark(group="timedelta_array_extend", warmup=False)
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ FAST_CASES = (LIST_1,)
 BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct")
+@pytest.mark.benchmark(group="timedelta_array_construct", warmup="off")
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -9,17 +9,20 @@ import nitypes.bintime as bt
 
 LIST_1 = [bt.TimeDelta(0.3)]
 LIST_10: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
-# LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
-# LIST_1000: list[bt.TimeDelta] = [
-#     bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
-# ]
-# LIST_10000: list[bt.TimeDelta] = [
-#     bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)
-# ]
+LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
+LIST_1000: list[bt.TimeDelta] = [
+    bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
+]
+LIST_10000: list[bt.TimeDelta] = [
+    bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)
+]
+
+FAST_CASES = (LIST_1,)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
 @pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("constructor_list", (LIST_10,))
+@pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.TimeDelta],
@@ -28,7 +31,7 @@ def test___bt_timedelta_array___construct(
 
 
 @pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_1,))
+@pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.TimeDelta],

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -18,7 +18,7 @@ LIST_10: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange
 
 
 @pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("constructor_list", (LIST_10))
+@pytest.mark.parametrize("constructor_list", (LIST_10,))
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.TimeDelta],
@@ -27,7 +27,7 @@ def test___bt_timedelta_array___construct(
 
 
 @pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1, max_time=0.5)
-@pytest.mark.parametrize("extend_list", (LIST_10))
+@pytest.mark.parametrize("extend_list", (LIST_10,))
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.TimeDelta],

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -17,7 +17,7 @@ LIST_10000: list[bt.TimeDelta] = [
 ]
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1)
+@pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=1, max_time=0.5)
 @pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1)
+@pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=1, max_time=0.5)
 @pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -26,7 +26,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend")
+@pytest.mark.benchmark(group="timedelta_array_extend", warmup="off")
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,


### PR DESCRIPTION
- Use the default of 5 instead

- [ ] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

TODO: Include high-level description of the changes in this pull request.

### Why should this Pull Request be merged?

TODO: Justify why this contribution should be part of the project.

### What testing has been done?

TODO: Detail what testing has been done to ensure this submission meets requirements.
