### PR TITLE
Fix #182 and reduce benchmark test times

### DIFF
--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -7,22 +7,24 @@ from pytest_benchmark.fixture import BenchmarkFixture
 import nitypes.bintime as bt
 
 
-LIST_10: list[bt.DateTime] = [
-    bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)
-]
-LIST_100: list[bt.DateTime] = [
+LIST_1 = [bt.DateTime.from_offset(bt.TimeDelta(0.3))]
+LIST_10 = [bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10, 0.3)]
+LIST_100 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 100, 0.3)
 ]
-LIST_1000: list[bt.DateTime] = [
+LIST_1000 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 1000, 0.3)
 ]
-LIST_10000: list[bt.DateTime] = [
+LIST_10000 = [
     bt.DateTime.from_offset(bt.TimeDelta(float(offset))) for offset in np.arange(0, 10000, 0.3)
 ]
 
+FAST_CASES = (LIST_1,)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
-@pytest.mark.benchmark(group="datetime_array_construct", min_rounds=100)
-@pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+
+@pytest.mark.benchmark(group="datetime_array_construct")
+@pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.DateTime],
@@ -30,8 +32,8 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend", min_rounds=100)
-@pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.benchmark(group="datetime_array_extend")
+@pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.DateTime],

--- a/tests/benchmark/bintime/test_datetime_array.py
+++ b/tests/benchmark/bintime/test_datetime_array.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from typing import Any
+
 import numpy as np
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
@@ -20,10 +23,18 @@ LIST_10000 = [
 ]
 
 FAST_CASES = (LIST_1,)
-BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)  # Useful for local measurements
 
 
-@pytest.mark.benchmark(group="datetime_array_construct")
+benchmark_options: dict[str, Any] = {}
+if sys.implementation.name == "pypy":
+    # See #182 -- PR/CI workflows spend too much time on PyPy benchmarks
+    benchmark_options["warmup"] = False
+    benchmark_options["min_rounds"] = 1
+    benchmark_options["max_time"] = 0.5
+
+
+@pytest.mark.benchmark(group="datetime_array_construct", **benchmark_options)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_datetime_array___construct(
     benchmark: BenchmarkFixture,
@@ -32,7 +43,7 @@ def test___bt_datetime_array___construct(
     benchmark(bt.DateTimeArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="datetime_array_extend")
+@pytest.mark.benchmark(group="datetime_array_extend", **benchmark_options)
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_datetime_array___extend(
     benchmark: BenchmarkFixture,

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -7,18 +7,18 @@ from pytest_benchmark.fixture import BenchmarkFixture
 import nitypes.bintime as bt
 
 
-LIST_10: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
-LIST_100: list[bt.TimeDelta] = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
-LIST_1000: list[bt.TimeDelta] = [
-    bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
-]
-LIST_10000: list[bt.TimeDelta] = [
-    bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)
-]
+LIST_1 = [bt.TimeDelta(0.3)]
+LIST_10 = [bt.TimeDelta(float(value)) for value in np.arange(-10, 10, 0.3)]
+LIST_100 = [bt.TimeDelta(float(value)) for value in np.arange(-100, 100, 0.3)]
+LIST_1000 = [bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)]
+LIST_10000 = [bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)]
+
+FAST_CASES = (LIST_1,)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct", min_rounds=100)
-@pytest.mark.parametrize("constructor_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.benchmark(group="timedelta_array_construct")
+@pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
     constructor_list: list[bt.TimeDelta],
@@ -26,8 +26,8 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend", min_rounds=100)
-@pytest.mark.parametrize("extend_list", (LIST_10, LIST_100, LIST_1000, LIST_10000))
+@pytest.mark.benchmark(group="timedelta_array_extend")
+@pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,
     extend_list: list[bt.TimeDelta],

--- a/tests/benchmark/bintime/test_timedelta_array.py
+++ b/tests/benchmark/bintime/test_timedelta_array.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import sys
+from typing import Any
+
 import numpy as np
 import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
@@ -14,10 +17,18 @@ LIST_1000 = [bt.TimeDelta(float(value)) for value in np.arange(-1000, 1000, 0.3)
 LIST_10000 = [bt.TimeDelta(float(value)) for value in np.arange(-10000, 10000, 0.3)]
 
 FAST_CASES = (LIST_1,)
-BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)
+BIG_O_CASES = (LIST_1, LIST_10, LIST_100, LIST_1000, LIST_10000)  # Useful for local measurements
 
 
-@pytest.mark.benchmark(group="timedelta_array_construct")
+benchmark_options: dict[str, Any] = {}
+if sys.implementation.name == "pypy":
+    # See #182 -- PR/CI workflows spend too much time on PyPy benchmarks
+    benchmark_options["warmup"] = False
+    benchmark_options["min_rounds"] = 1
+    benchmark_options["max_time"] = 0.5
+
+
+@pytest.mark.benchmark(group="timedelta_array_construct", **benchmark_options)
 @pytest.mark.parametrize("constructor_list", FAST_CASES)
 def test___bt_timedelta_array___construct(
     benchmark: BenchmarkFixture,
@@ -26,7 +37,7 @@ def test___bt_timedelta_array___construct(
     benchmark(bt.TimeDeltaArray, constructor_list)
 
 
-@pytest.mark.benchmark(group="timedelta_array_extend")
+@pytest.mark.benchmark(group="timedelta_array_extend", **benchmark_options)
 @pytest.mark.parametrize("extend_list", FAST_CASES)
 def test___bt_timedelta_array___extend(
     benchmark: BenchmarkFixture,


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Add and use a length-1 list test case by default for the array tests
- Remove constraints from array benchmark tests
- Remove type hints from constants

### Why should this Pull Request be merged?

This reduces the time for the MacOS PyPy benchmarks from 15 minutes to 5 minutes.

### What testing has been done?

- PR build and checks