### PR TITLE
Add start_index property to DigitalWaveform and NumericWaveform

### DIFF
--- a/src/nitypes/waveform/_digital/_waveform.py
+++ b/src/nitypes/waveform/_digital/_waveform.py
@@ -923,6 +923,11 @@ class DigitalWaveform(Generic[TDigitalState]):
         return shape[1]
 
     @property
+    def start_index(self) -> int:
+        """The sample index of the underlying array at which the waveform data begins."""
+        return self._start_index
+
+    @property
     def capacity(self) -> int:
         """The total capacity available for waveform data.
 

--- a/src/nitypes/waveform/_numeric.py
+++ b/src/nitypes/waveform/_numeric.py
@@ -467,6 +467,11 @@ class NumericWaveform(ABC, Generic[_TRaw, _TScaled]):
         self._sample_count = value
 
     @property
+    def start_index(self) -> int:
+        """The sample index of the underlying array at which the waveform data begins."""
+        return self._start_index
+
+    @property
     def capacity(self) -> int:
         """The total capacity available for waveform data.
 

--- a/tests/unit/waveform/test_analog_waveform.py
+++ b/tests/unit/waveform/test_analog_waveform.py
@@ -580,6 +580,7 @@ def test___array_subset___from_array_2d___creates_waveform_with_array_subset(
     assert len(waveforms) == 2
     for i in range(len(waveforms)):
         assert waveforms[i].raw_data.tolist() == expected_data[i]
+        assert waveforms[i].start_index == (start_index if start_index is not None else 0)
 
 
 @pytest.mark.parametrize(
@@ -1595,13 +1596,13 @@ def test___waveform_with_start_index___load_data___clears_start_index() -> None:
     waveform = AnalogWaveform.from_array_1d(
         np.array([0, 1, 2], np.int32), np.int32, copy=False, start_index=1, sample_count=1
     )
-    assert waveform._start_index == 1
+    assert waveform.start_index == 1
     array = np.array([3], np.int32)
 
     waveform.load_data(array)
 
     assert list(waveform.raw_data) == [3]
-    assert waveform._start_index == 0
+    assert waveform.start_index == 0
 
 
 def test___ndarray_subset___load_data___overwrites_data() -> None:
@@ -1611,7 +1612,7 @@ def test___ndarray_subset___load_data___overwrites_data() -> None:
     waveform.load_data(array, start_index=1, sample_count=1)
 
     assert list(waveform.raw_data) == [4]
-    assert waveform._start_index == 0
+    assert waveform.start_index == 0
     assert waveform.capacity == 3
 
 

--- a/tests/unit/waveform/test_digital_waveform.py
+++ b/tests/unit/waveform/test_digital_waveform.py
@@ -321,6 +321,7 @@ def test___array_subset___from_port___creates_waveform_with_array_subset() -> No
 
     waveform = DigitalWaveform.from_port(array, start_index=2, sample_count=4)
 
+    assert waveform.start_index == 2
     assert waveform.sample_count == 4
     assert waveform.signal_count == 8
     assert waveform.data.tolist() == [
@@ -448,11 +449,13 @@ def test___array_subset___from_ports___creates_waveform_with_array_subset() -> N
     waveforms = DigitalWaveform.from_ports(array, start_index=1, sample_count=1)
 
     assert len(waveforms) == 2
+    assert waveforms[0].start_index == 1
     assert waveforms[0].sample_count == 1
     assert waveforms[0].signal_count == 8
     assert waveforms[0].data.tolist() == [
         [1, 0, 0, 0, 0, 0, 0, 0],
     ]
+    assert waveforms[1].start_index == 1
     assert waveforms[1].sample_count == 1
     assert waveforms[1].signal_count == 8
     assert waveforms[1].data.tolist() == [
@@ -1270,13 +1273,13 @@ def test___waveform_with_start_index___load_data___clears_start_index() -> None:
     waveform = DigitalWaveform.from_lines(
         np.array([[0], [1], [2]], np.uint8), np.uint8, copy=False, start_index=1, sample_count=1
     )
-    assert waveform._start_index == 1
+    assert waveform.start_index == 1
     array = np.array([[3]], np.uint8)
 
     waveform.load_data(array)
 
     assert waveform.data.tolist() == [[3]]
-    assert waveform._start_index == 0
+    assert waveform.start_index == 0
 
 
 def test___ndarray_subset___load_data___overwrites_data() -> None:
@@ -1286,7 +1289,7 @@ def test___ndarray_subset___load_data___overwrites_data() -> None:
     waveform.load_data(array, start_index=1, sample_count=1)
 
     assert waveform.data.tolist() == [[4]]
-    assert waveform._start_index == 0
+    assert waveform.start_index == 0
     assert waveform.capacity == 3
 
 


### PR DESCRIPTION

- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Adds `DigitalWaveform.start_index` and `NumericWaveform.start_index` as read-only properties.

### Why should this Pull Request be merged?

AB#3258929

### What testing has been done?

Added and updated asserts in existing tests.
