### PR TITLE
Add typing_extensions as a main dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1943,7 +1943,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["docs", "lint", "test"]
+groups = ["main", "docs", "lint", "test"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -2023,4 +2023,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "741864716565298bae1dfd67d4f6c5d50d6663142daf87e20ca41defca76f672"
+content-hash = "d4cfa03a4e1ff9a74b4e26d646fb75dd6e4284362f2a116af72961cf7befec77"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2023,4 +2023,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<4.0"
-content-hash = "d4cfa03a4e1ff9a74b4e26d646fb75dd6e4284362f2a116af72961cf7befec77"
+content-hash = "162a134296fabd07c89f1a0c30010ebdfd7723a5c17a14b615e699806be958b0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ numpy = [
   { version = ">=2.1", python = "^3.13" }
 ]
 hightime = { version = ">=0.2.2", allow-prereleases = true }
-typing_extensions = { version = ">=4.0.0" }
+typing-extensions = ">=4.13.2"
 
 [tool.poetry.group.dev.dependencies]
 # Specify additional NumPy version constraints to speed up locking and test with binary wheels that support PyPy.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ numpy = [
   { version = ">=2.1", python = "^3.13" }
 ]
 hightime = { version = ">=0.2.2", allow-prereleases = true }
+typing_extensions = { version = ">=4.0.0" }
 
 [tool.poetry.group.dev.dependencies]
 # Specify additional NumPy version constraints to speed up locking and test with binary wheels that support PyPy.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This adds an explicit dependency on typing_extensions.

### Why should this Pull Request be merged?

When I [tried to use](https://github.com/ni/nidaqmx-python/pull/827) the latest version of nitypes in the nidaqmx repo, I [got this error](https://github.com/ni/nidaqmx-python/actions/runs/17624550105/job/50078119013) when running tests with Python 3.11+:
```
.venv\Lib\site-packages\nitypes\waveform\_analog.py:8: in <module>
    from typing_extensions import TYPE_CHECKING, TypeVar, final, override
E   ModuleNotFoundError: No module named 'typing_extensions'
```

I think the upgrade to poetry 2.1 changed how the typing_extensions dependency works. For older versions of Python, it's still implicitly provided, but for the newer versions, it isn't. But since _analog.py is trying to import the typing_extensions module, I think it makes sense for nitypes to explicitly list it as a dependency so that is guaranteed to be available.

### What testing has been done?

I'm hoping this change would fix the issue in nidaqmx without nidaqmx having to explicitly depend on typing_extensions, but I don't know how to test that before submitting this PR.

(Note: I went ahead and added the typing_extensions dependency to nidaqmx, so this PR isn't actually needed for that, although it might be a good idea regardless?)
