### PR TITLE
Create an XYData class

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
   - [Binary Time](#binary-time)
 - [Scalar Values](#scalar-values)
   - [Scalar](#scalar)
+  - [Vector](#vector)
+  - [XYData](#xydata)
 
 # About
 
@@ -141,4 +143,11 @@ API Reference.
 information and extended properties. Valid types for the scalar values are `bool`, `int`, `float`,
 and `str`. For more details, see
 [Scalar](https://nitypes.readthedocs.io/en/latest/autoapi/nitypes/vector/index.html#vector) in the
+API Reference.
+
+## XYData
+
+`nitypes.xy_data.XYData` is a data type that represents a two dimensional sequence of numeric values with
+units information. Valid types for the numeric values are `int` and `float`. For more details, see
+[XYData](https://nitypes.readthedocs.io/en/latest/autoapi/nitypes/xy_data/index.html#xy_data) in the
 API Reference.

--- a/src/nitypes/xy_data.py
+++ b/src/nitypes/xy_data.py
@@ -1,0 +1,229 @@
+"""XYData type for NI Python APIs.
+
+XYData Data Type
+=================
+:class:`XYData`: An XYData object represents a two dimensional sequence of numeric values with
+units information. Valid types for the numeric values are :any:`int` and :any:`float`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, MutableSequence
+from typing import TYPE_CHECKING, Any, Generic, Union
+
+from typing_extensions import TypeVar, final
+
+from nitypes._exceptions import invalid_arg_type
+from nitypes.waveform._extended_properties import UNIT_DESCRIPTION
+
+if TYPE_CHECKING:
+    # Import from the public package so the docs don't reference private submodules.
+    from nitypes.waveform import ExtendedPropertyDictionary
+else:
+    from nitypes.waveform._extended_properties import ExtendedPropertyDictionary
+
+TNumeric = TypeVar("TNumeric", bound=Union[int, float])
+
+
+@final
+class XYData(Generic[TNumeric]):
+    """A 2D sequence of numeric data with units and extended properties.
+
+    Constructing
+    ^^^^^^^^^^^^
+
+    To construct an XYData object, use the :class:`XYData` class:
+
+    >>> XYData([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+    nitypes.xy_data.XYData(x_data=[1.0, 2.0, 3.0], y_data=[4.0, 5.0, 6.0], x_units='', y_units='')
+    >>> XYData([1, 2, 3], [4, 5, 6], "A", "V")
+    nitypes.xy_data.XYData(x_data=[1, 2, 3], y_data=[4, 5, 6], x_units='A', y_units='V')
+    """
+
+    __slots__ = [
+        "_values",
+        "_value_type",
+        "_extended_properties",
+    ]
+
+    _values: list[list[TNumeric]]
+    _value_type: type[TNumeric]
+    _extended_properties: ExtendedPropertyDictionary
+
+    def __init__(
+        self,
+        x_values: Iterable[TNumeric],
+        y_values: Iterable[TNumeric],
+        x_units: str = "",
+        y_units: str = "",
+        *,
+        value_type: type[TNumeric] | None = None,
+    ) -> None:
+        """Initialize a new XYData.
+
+        Args:
+            x_values: The numeric values to store in first dimension of this object.
+            y_values: The numeric values to store in second dimension of this object.
+            x_units: The units string associated with x_values.
+            y_units: The units string associated with y_values.
+            value_type: The type of values that will be added to this XYData.
+                This parameter should only be used when creating an XYData with
+                empty Iterables.
+
+        Returns:
+            An XYData object.
+        """
+        if not x_values and not y_values:
+            if not value_type:
+                raise TypeError(
+                    "You must specify x_values and y_values as non-empty or specify value_type."
+                )
+            self._value_type = value_type
+        else:
+            # Use the first x_value to determine _value_type.
+            self._value_type = type(next(iter(x_values)))
+
+            # Validate the values inputs
+            self._validate_axis_data(x_values)
+            self._validate_axis_data(y_values)
+
+        if not isinstance(x_units, str):
+            raise invalid_arg_type("x_units", "str", x_units)
+
+        if not isinstance(y_units, str):
+            raise invalid_arg_type("y_units", "str", y_units)
+
+        self._values = [list(x_values), list(y_values)]
+        if len(self._values[0]) != len(self._values[1]):
+            raise ValueError("x_values and y_values must be the same length.")
+
+        # X units and Y units are combined since there is only one units key.
+        self._extended_properties = ExtendedPropertyDictionary()
+        self._extended_properties[UNIT_DESCRIPTION] = ",".join([x_units, y_units])
+
+    @property
+    def x_data(self) -> MutableSequence[TNumeric]:
+        """The x-axis data of this XYData."""
+        return self._values[0]
+
+    @property
+    def y_data(self) -> MutableSequence[TNumeric]:
+        """The y-axis data of this XYData."""
+        return self._values[1]
+
+    @property
+    def x_units(self) -> str:
+        """The unit of measurement, such as volts, of x_data."""
+        value = self._extended_properties.get(UNIT_DESCRIPTION, "")
+        assert isinstance(value, str)
+        return value.split(",")[0] if value else ""
+
+    @x_units.setter
+    def x_units(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise invalid_arg_type("x_units", "str", value)
+        self._extended_properties[UNIT_DESCRIPTION] = ",".join([value, self.y_units])
+
+    @property
+    def y_units(self) -> str:
+        """The unit of measurement, such as volts, of y_data."""
+        value = self._extended_properties.get(UNIT_DESCRIPTION, "")
+        assert isinstance(value, str)
+        return value.split(",")[1] if value else ""
+
+    @y_units.setter
+    def y_units(self, value: str) -> None:
+        if not isinstance(value, str):
+            raise invalid_arg_type("y_units", "str", value)
+        self._extended_properties[UNIT_DESCRIPTION] = ",".join([self.x_units, value])
+
+    @property
+    def extended_properties(self) -> ExtendedPropertyDictionary:
+        """The extended properties for the XYData.
+
+        .. note::
+            Data stored in the extended properties dictionary may not be encrypted when you send it
+            over the network or write it to a TDMS file.
+        """
+        return self._extended_properties
+
+    def append(self, x_value: TNumeric, y_value: TNumeric) -> None:
+        """Append an x and y value pair to this XYData."""
+        self._validate_axis_data([x_value])
+        self._validate_axis_data([y_value])
+        self.x_data.append(x_value)
+        self.y_data.append(y_value)
+
+    def extend(
+        self, x_values: MutableSequence[TNumeric], y_values: MutableSequence[TNumeric]
+    ) -> None:
+        """Extend x_data and y_data with the input sequences."""
+        if len(x_values) != len(y_values):
+            raise ValueError("X and Y sequences to extend must be the same length.")
+
+        self._validate_axis_data(x_values)
+        self._validate_axis_data(y_values)
+        self.x_data.extend(x_values)
+        self.y_data.extend(y_values)
+
+    def __len__(self) -> int:
+        """Return the length of x_data and y_data."""
+        return len(self.x_data)
+
+    def __eq__(self, value: object, /) -> bool:
+        """Return self==value."""
+        if not isinstance(value, self.__class__):
+            return NotImplemented
+        return (
+            self._values == value._values
+            and self.x_units == value.x_units
+            and self.y_units == value.y_units
+        )
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Return object state for pickling."""
+        return (self.__class__, (self.x_data, self.y_data, self.x_units, self.y_units))
+
+    def __repr__(self) -> str:
+        """Return repr(self)."""
+        args = [
+            f"x_data={self.x_data!r}",
+            f"y_data={self.y_data!r}",
+            f"x_units={self.x_units!r}",
+            f"y_units={self.y_units!r}",
+        ]
+        return f"{self.__class__.__module__}.{self.__class__.__name__}({', '.join(args)})"
+
+    def __str__(self) -> str:
+        """Return str(self)."""
+        if self.x_units:
+            x_values_with_units = [f"{value} {self.x_units}" for value in self.x_data]
+            x_str = ", ".join(x_values_with_units)
+        else:
+            x_values = [f"{value}" for value in self.x_data]
+            x_str = ", ".join(x_values)
+        x_str = f"[{x_str}]"
+
+        if self.y_units:
+            y_values_with_units = [f"{value} {self.y_units}" for value in self.y_data]
+            y_str = ", ".join(y_values_with_units)
+        else:
+            y_values = [f"{value}" for value in self.y_data]
+            y_str = ", ".join(y_values)
+        y_str = f"[{y_str}]"
+
+        return f"[{x_str}, {y_str}]"
+
+    def _validate_axis_data(self, values: Iterable[TNumeric]) -> None:
+        for value in values:
+            if not isinstance(value, (int, float)):
+                raise invalid_arg_type("XYData input data", "int or float", value)
+
+            if not isinstance(value, self._value_type):
+                raise self._create_value_mismatch_exception(value)
+
+    def _create_value_mismatch_exception(self, value: object) -> TypeError:
+        return TypeError(
+            f"Input data does not match expected type. Input Type: {type(value)} "
+            f"Expected Type: {self._value_type}"
+        )

--- a/tests/unit/xy_data/__init__.py
+++ b/tests/unit/xy_data/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for the nitypes.xy_data package."""

--- a/tests/unit/xy_data/test_xy_data.py
+++ b/tests/unit/xy_data/test_xy_data.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import copy
+import pickle
+from typing import Any
+
+import pytest
+from typing_extensions import assert_type
+
+from nitypes.waveform._extended_properties import (
+    UNIT_DESCRIPTION,
+    ExtendedPropertyDictionary,
+)
+from nitypes.xy_data import TNumeric, XYData
+
+
+###############################################################################
+# create
+###############################################################################
+def test___no_data_values_no_type___create___raises_type_error() -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = XYData([], [])
+
+    assert exc.value.args[0].startswith(
+        "You must specify x_values and y_values as non-empty or specify value_type."
+    )
+
+
+def test___no_data_values_int_type___create___creates_with_int_type() -> None:
+    data = XYData([], [], value_type=int)
+
+    assert_type(data._values, list[list[int]])
+    assert data.x_data == []
+    assert data.y_data == []
+    assert data.x_units == data.y_units == ""
+    assert data._value_type == int
+
+
+def test___int_data_values___create___creates_with_int_data_and_default_units() -> None:
+    data = XYData([10, 20, 30], [40, 50, 60])
+
+    assert_type(data._values[0][0], int)
+    assert data.x_data == [10, 20, 30]
+    assert data.y_data == [40, 50, 60]
+    assert data.x_units == data.y_units == ""
+
+
+def test___float_data_value___create___creates_with_float_data_and_default_units() -> None:
+    data = XYData([20.2, 30.3, 40.4], [50.5, 60.6, 70.7])
+
+    assert_type(data._values[0][0], float)
+    assert data.x_data == [20.2, 30.3, 40.4]
+    assert data.y_data == [50.5, 60.6, 70.7]
+    assert data.x_units == data.y_units == ""
+
+
+def test___float_data_value_and_units___create___creates_with_float_data_and_units() -> None:
+    expected_x_data = [1.1, 2.2, 3.3]
+    expected_x_units = "volts"
+    expected_y_data = [4.4, 5.5, 6.6]
+    expected_y_units = "seconds"
+
+    data = XYData(expected_x_data, expected_y_data, expected_x_units, expected_y_units)
+
+    assert data.x_data == expected_x_data
+    assert data.y_data == expected_y_data
+    assert data.x_units == expected_x_units
+    assert data.y_units == expected_y_units
+
+
+@pytest.mark.parametrize("data_value", [[[1.0, 2.0]], [{"key", "value"}]])
+def test___invalid_data_value___create___raises_type_error(data_value: Any) -> None:
+    with pytest.raises(TypeError) as exc:
+        _ = XYData(data_value, data_value)
+
+    assert exc.value.args[0].startswith("The XYData input data must be an int or float.")
+
+
+def test___mixed_data_values___create___raises_type_error() -> None:
+    with pytest.raises(TypeError) as exc:
+        mixed_data = [1.0, 2, 3]
+        _ = XYData(mixed_data, mixed_data)
+
+    assert exc.value.args[0].startswith("Input data does not match expected type.")
+
+
+def test___int_data_values_length_mismatch___create___raises_value_error() -> None:
+    with pytest.raises(ValueError) as exc:
+        _ = XYData([1, 2], [3, 4, 5])
+
+    assert exc.value.args[0].startswith("x_values and y_values must be the same length.")
+
+
+###############################################################################
+# append
+###############################################################################
+def test___xy_data___append_same_type___values_appended() -> None:
+    data = XYData([1, 2, 3], [7, 6, 5])
+
+    data.append(4, 4)
+
+    assert data.x_data == [1, 2, 3, 4]
+    assert data.y_data == [7, 6, 5, 4]
+
+
+def test___xy_data___append_different_type___raises_type_error() -> None:
+    data = XYData([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+
+    with pytest.raises(TypeError) as exc:
+        data.append(True, False)
+
+    assert exc.value.args[0].startswith("Input data does not match expected type.")
+
+
+def test___empty_xy_data___append___appends_data() -> None:
+    data = XYData([], [], value_type=int)
+    data.append(1, 2)
+
+    assert data.x_data == [1]
+    assert data.y_data == [2]
+
+
+###############################################################################
+# extend
+###############################################################################
+def test___xy_data___extend_same_type___values_extended() -> None:
+    data = XYData([1, 2, 3], [4, 5, 6])
+
+    data.extend([4, 5], [7, 8])
+
+    assert data.x_data == [1, 2, 3, 4, 5]
+    assert data.y_data == [4, 5, 6, 7, 8]
+
+
+def test___xy_data___extend_different_type___raises_type_error() -> None:
+    data = XYData([1.0, 2.0, 3.0], [4.0, 5.0, 6.0])
+
+    with pytest.raises(TypeError) as exc:
+        data.extend([1, 2], [3, 4])
+
+    assert exc.value.args[0].startswith("Input data does not match expected type.")
+
+
+def test___xy_data___extend_mixed_lengths___raises_value_error() -> None:
+    data = XYData([1, 2, 3], [4, 5, 6])
+
+    with pytest.raises(ValueError) as exc:
+        data.extend([1, 2, 3], [4, 5])
+
+    assert exc.value.args[0].startswith("X and Y sequences to extend must be the same length.")
+
+
+def test___empty_xy_data___extend___values_extended() -> None:
+    data = XYData([], [], value_type=float)
+    data.extend([1.0, 2.0], [3.0, 4.0])
+
+    assert data.x_data == [1.0, 2.0]
+    assert data.y_data == [3.0, 4.0]
+
+
+def test___xy_data___extend_with_empty_list___values_unchanged() -> None:
+    data = XYData([1, 2, 3], [4, 5, 6])
+
+    data.extend([], [])
+
+    assert data.x_data == [1, 2, 3]
+    assert data.y_data == [4, 5, 6]
+
+
+###############################################################################
+# length
+###############################################################################
+def test___xy_data___check_length___length_correct() -> None:
+    xy_data = XYData([1, 2], [3, 4])
+
+    assert len(xy_data) == 2
+
+
+###############################################################################
+# compare
+###############################################################################
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (XYData([1, 2], [3, 4]), XYData([1, 2], [3, 4])),
+        (XYData([1.0, 2.0], [3.0, 4.0]), XYData([1.0, 2.0], [3.0, 4.0])),
+    ],
+)
+def test___same_value___comparison___equal(left: XYData[TNumeric], right: XYData[TNumeric]) -> None:
+    assert left == right
+
+
+@pytest.mark.parametrize(
+    "left, right",
+    [
+        (XYData([1, 2], [5, 6]), XYData([1, 2], [3, 4])),
+        (XYData([1.0, 2.0], [5.0, 6.0]), XYData([1.0, 2.0], [3.0, 4.0])),
+    ],
+)
+def test___different_values___comparison___not_equal(
+    left: XYData[TNumeric], right: XYData[TNumeric]
+) -> None:
+    assert left != right
+
+
+def test___different_units___comparison___not_equal() -> None:
+    left = XYData([0], [0], "volts", "seconds")
+    right = XYData([0], [0], "amps", "seconds")
+
+    assert left != right
+
+
+###############################################################################
+# other operators
+###############################################################################
+@pytest.mark.parametrize(
+    "value, expected_repr",
+    [
+        (
+            XYData([10], [20]),
+            "nitypes.xy_data.XYData(x_data=[10], y_data=[20], x_units='', y_units='')",
+        ),
+        (
+            XYData([1.0, 1.1], [1.2, 1.3]),
+            "nitypes.xy_data.XYData(x_data=[1.0, 1.1], y_data=[1.2, 1.3], x_units='', y_units='')",
+        ),
+        (
+            XYData([10], [20], "volts", "s"),
+            "nitypes.xy_data.XYData(x_data=[10], y_data=[20], x_units='volts', y_units='s')",
+        ),
+    ],
+)
+def test___various_values___repr___looks_ok(value: XYData[Any], expected_repr: str) -> None:
+    assert repr(value) == expected_repr
+
+
+@pytest.mark.parametrize(
+    "value, expected_str",
+    [
+        (XYData([], [], value_type=int), "[[], []]"),
+        (XYData([], [], "volts", "s", value_type=int), "[[], []]"),
+        (XYData([10, 20], [30, 40]), "[[10, 20], [30, 40]]"),
+        (XYData([10.0, 20.0], [30.0, 40.0]), "[[10.0, 20.0], [30.0, 40.0]]"),
+        (XYData([10], [20], "volts", "s"), "[[10 volts], [20 s]]"),
+        (XYData([1, 2], [3, 4], "miles", "hr"), "[[1 miles, 2 miles], [3 hr, 4 hr]]"),
+    ],
+)
+def test___various_values___str___looks_ok(value: XYData[Any], expected_str: str) -> None:
+    assert str(value) == expected_str
+
+
+###############################################################################
+# other properties
+###############################################################################
+def test___xy_data_with_units___get_extended_properties___returns_correct_dictionary() -> None:
+    value = XYData([20.0], [40.0], "watts", "hr")
+
+    prop_dict = value.extended_properties
+
+    assert isinstance(prop_dict, ExtendedPropertyDictionary)
+    assert prop_dict.get(UNIT_DESCRIPTION) == "watts,hr"
+
+
+def test___xy_data_with_units___set_units___units_updated_correctly() -> None:
+    value = XYData([20.0], [40.0], "watts", "hr")
+
+    value.x_units = "volts"
+    value.y_units = "s"
+
+    assert value.x_units == "volts"
+    assert value.y_units == "s"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        XYData([10, 20], [30, 40]),
+        XYData([20.0, 20.1], [20.3, 20.4]),
+        XYData([10, 20], [30, 40], "A", "B"),
+        XYData([20.0, 20.1], [20.3, 20.4], "C", "D"),
+    ],
+)
+def test___various_values___copy___makes_copy(value: XYData[TNumeric]) -> None:
+    new_value = copy.copy(value)
+    assert new_value is not value
+    assert new_value == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        XYData([10, 20], [30, 40]),
+        XYData([20.0, 20.1], [20.3, 20.4]),
+        XYData([10, 20], [30, 40], "A", "B"),
+        XYData([20.0, 20.1], [20.3, 20.4], "C", "D"),
+    ],
+)
+def test___various_values___pickle_unpickle___makes_copy(value: XYData[TNumeric]) -> None:
+    new_value = pickle.loads(pickle.dumps(value))
+    assert new_value is not value
+    assert new_value == value
+
+
+def test___xy_data___pickle___references_public_modules() -> None:
+    value = XYData([10, 20], [30, 40])
+    value_bytes = pickle.dumps(value)
+
+    assert b"nitypes.xy_data" in value_bytes
+    assert b"nitypes.xy_data._xy_data" not in value_bytes


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Creates an `XYData` python class to back to the xy_data protobuf type.

### Why should this Pull Request be merged?

Implements the nitypes portion of AB#3266236

### What testing has been done?

New unit tests added. All unit tests pass. Also mypy, pyright, styleguide.
