### PR TITLE
github: Update workflows to use the 'case' function

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   dist-artifact-name: nitypes-distribution-packages
-  environment: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+  environment: ${{ case(github.event_name == 'release', 'pypi', inputs.environment) }}
   environment-info: |
     {
       "pypi": {
@@ -65,7 +65,7 @@ jobs:
     needs: [build_nitypes]
     environment:
       # This logic is duplicated because `name` doesn't support the `env` context.
-      name: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+      name: ${{ case(github.event_name == 'release', 'pypi', inputs.environment) }}
       url: ${{ fromJson(env.environment-info)[env.environment].base-url }}/p/nitypes
     permissions:
       id-token: write

--- a/.github/workflows/sync_github_issues_to_azdo.yml
+++ b/.github/workflows/sync_github_issues_to_azdo.yml
@@ -13,16 +13,6 @@ jobs:
     if: ${{ !github.event.issue.pull_request && github.event.issue.title != 'Dependency Dashboard' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Choose work item type
-        id: choose_work_item_type
-        run: |
-          if [ "${{ contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'user story') }}" == "true" ]; then
-            echo "work_item_type=User Story" >> $GITHUB_OUTPUT
-          elif [ "${{ contains(github.event.issue.labels.*.name, 'tech debt') }}" == "true" ]; then
-            echo "work_item_type=Technical Debt" >> $GITHUB_OUTPUT
-          else
-            echo "work_item_type=Bug" >> $GITHUB_OUTPUT
-          fi
       - uses: danhellem/github-actions-issue-to-work-item@45eb3b46e684f2acd2954f02ef70350c835ee4bb # v2.4
         env:
           ado_token: "${{ secrets.AZDO_WORK_ITEM_TOKEN }}"
@@ -30,7 +20,10 @@ jobs:
           ado_organization: "ni"
           ado_project: "DevCentral"
           ado_area_path: "DevCentral\\Product RnD\\Platform HW and SW\\SW New Invest and Tech\\ETW\\Python CodeGen"
-          ado_wit: "${{ steps.choose_work_item_type.outputs.work_item_type }}"
+          ado_wit: "${{ case(
+            contains(github.event.issue.labels.*.name, 'enhancement') || contains(github.event.issue.labels.*.name, 'user story'), 'User Story',
+            contains(github.event.issue.labels.*.name, 'tech debt'), 'Technical Debt',
+            'Bug') }}"
           ado_new_state: "New"
           ado_active_state: "Active"
           ado_close_state: "Closed"


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update GitHub Actions workflows to add the new 'case' function ( https://github.blog/changelog/2026-01-29-github-actions-smarter-editing-clearer-debugging-and-a-new-case-function/ ) rather than bash scripts or `${{ condition && true-value || false-value }}`.

### Why should this Pull Request be merged?

Clarify intent & improve readability

Avoid using bash in `sync_github_issues_to_azdo.yml`

### What testing has been done?

Tested in a personal fork of the repo:
- sync_github_issues_to_azdo.yml: https://github.com/bkeryan/nitypes-python/actions/runs/24051896662/job/70149320202
- publish.yml: https://github.com/bkeryan/nitypes-python/actions/runs/24051835682/job/70149440265