### PR TITLE
github: Stop testing with pypy3.10

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python-version: [3.9, '3.10', 3.11, 3.12, 3.13, 3.14, 3.14t, pypy3.10, pypy3.11]
+        python-version: [3.9, '3.10', 3.11, 3.12, 3.13, 3.14, 3.14t, pypy3.11]
       # Fail-fast skews the pass/fail ratio and seems to make pytest produce
       # incomplete JUnit XML results.
       fail-fast: false


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Stop running tests on pypy3.10.

### Why should this Pull Request be merged?

Fix CI build.

The Python `cryptography` package no longer builds with `pypy3.10` because the Rust [pyo3](https://crates.io/crates/pyo3/0.28.2) crate now supports "PyPy 7.3 (Python 3.11+)".

### What testing has been done?

PR build.