### PR TITLE
Vector - Support Single-Pass Iterables

### DIFF
--- a/src/nitypes/vector.py
+++ b/src/nitypes/vector.py
@@ -8,7 +8,7 @@ Valid types for the scalar value are :any:`bool`, :any:`int`, :any:`float`, and 
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, MutableSequence
+from collections.abc import Iterable, Mapping, MutableSequence, Sequence
 from typing import TYPE_CHECKING, Any, Union, overload
 
 from typing_extensions import Self, TypeVar, final, override
@@ -79,19 +79,18 @@ class Vector(MutableSequence[TScalar]):
         Returns:
             A vector data object.
         """
-        if not values:
+        backing_values = list(values)
+        if not backing_values:
             if not value_type:
                 raise TypeError("You must specify values as non-empty or specify value_type.")
             self._value_type = value_type
         else:
-            # Validate the values input
-            for index, value in enumerate(values):
-                # Only set _value_type once.
-                if not index:
-                    self._value_type = type(value)
-
+            self._value_type = type(backing_values[0])
+            for value in backing_values:
                 if not isinstance(value, (bool, int, float, str)):
-                    raise invalid_arg_type("vector input data", "bool, int, float, or str", values)
+                    raise invalid_arg_type(
+                        "vector input data", "bool, int, float, or str", backing_values
+                    )
 
                 if not isinstance(value, self._value_type):
                     raise TypeError("All values in the values input must be of the same type.")
@@ -99,7 +98,7 @@ class Vector(MutableSequence[TScalar]):
         if not isinstance(units, str):
             raise invalid_arg_type("units", "str", units)
 
-        self._values = list(values)
+        self._values = backing_values
         if copy_extended_properties or not isinstance(
             extended_properties, ExtendedPropertyDictionary
         ):
@@ -178,14 +177,20 @@ class Vector(MutableSequence[TScalar]):
                 raise TypeError("You must assign an Iterable to a Vector slice.")
             elif isinstance(value, str):  # Narrow the type to exclude string.
                 raise TypeError("You cannot assign a string to Vector slice.")
-            else:
-                # Assigning an empty Iterable to a slice is valid, so we don't check for empty.
-                # If an empty Iterable is assigned to a slice, that slice is deleted.
-                for subval in value:
-                    if not isinstance(subval, self._value_type):
-                        raise self._create_value_mismatch_exception(subval)
 
-            self._values[index] = value
+            if isinstance(value, Sequence):
+                # A Sequence can be iterated over multiple times, so no need for a wrapper list.
+                replacement_values = value
+            else:
+                replacement_values = list(value)
+
+            # Assigning an empty Iterable to a slice is valid, so we don't check for empty.
+            # If an empty Iterable is assigned to a slice, that slice is deleted.
+            for subval in replacement_values:
+                if not isinstance(subval, self._value_type):
+                    raise self._create_value_mismatch_exception(subval)
+
+            self._values[index] = replacement_values
 
     def __delitem__(self, index: int | slice) -> None:
         """Delete item(s) from the specified location."""

--- a/src/nitypes/vector.py
+++ b/src/nitypes/vector.py
@@ -86,6 +86,7 @@ class Vector(MutableSequence[TScalar]):
             self._value_type = value_type
         else:
             self._value_type = type(backing_values[0])
+            # Validate the values input
             for value in backing_values:
                 if not isinstance(value, (bool, int, float, str)):
                     raise invalid_arg_type(

--- a/tests/unit/vector/test_vector.py
+++ b/tests/unit/vector/test_vector.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import copy
 import pickle
+from collections.abc import Iterable
 from typing import Any
 
 import pytest
@@ -51,7 +52,7 @@ def test___int_data_values___create___creates_with_int_data_and_default_units() 
     assert data.units == ""
 
 
-def test___float_data_value___create___creates_scalar_data_with_data_and_default_units() -> None:
+def test___float_data_values___create___creates_with_float_data_and_default_units() -> None:
     data = Vector([20.2, 30.3, 40.4])
 
     assert_type(data._values[0], float)
@@ -59,11 +60,24 @@ def test___float_data_value___create___creates_scalar_data_with_data_and_default
     assert data.units == ""
 
 
-def test___str_data_value___create___creates_scalar_data_with_data_and_default_units() -> None:
+def test___str_data_values___create___creates_with_str_data_and_default_units() -> None:
     data = Vector(["one", "two"])
 
     assert_type(data._values[0], str)
     assert data._values == ["one", "two"]
+    assert data.units == ""
+
+
+def test___generator_data_values___create___creates_with_data_and_default_units() -> None:
+    def get_values() -> Iterable[float]:
+        yield 20.2
+        yield 30.3
+        yield 40.4
+
+    data = Vector(get_values())
+
+    assert_type(data._values[0], float)
+    assert data._values == [20.2, 30.3, 40.4]
     assert data.units == ""
 
 
@@ -99,6 +113,29 @@ def test___invalid_data_value___create___raises_type_error(data_value: Any) -> N
         _ = Vector(data_value)
 
     assert exc.value.args[0].startswith("The vector input data must be a bool, int, float, or str.")
+
+
+def test___invalid_generator_data_values___create___raises_type_error() -> None:
+    def get_values() -> Iterable[Any]:
+        yield from [{"test_key", "test_value"}, 1.0, 2.0]
+
+    with pytest.raises(TypeError) as exc:
+        _ = Vector(get_values())
+
+    assert exc.value.args[0].startswith("The vector input data must be a bool, int, float, or str.")
+    assert "{'test_key', 'test_value'}" in exc.value.args[0]
+
+
+def test___empty_generator_data_values___create___raises_type_error() -> None:
+    def get_values() -> Iterable[float]:
+        yield from []
+
+    with pytest.raises(TypeError) as exc:
+        _ = Vector(get_values())
+
+    assert exc.value.args[0].startswith(
+        "You must specify values as non-empty or specify value_type."
+    )
 
 
 def test___mixed_data_values___create___raises_type_error() -> None:
@@ -143,6 +180,19 @@ def test___vector_with_data___set_item_at_slice___values_set_correctly() -> None
     vector = Vector([1, 2, 3], "volts")
 
     vector[0:2] = [6, 7]
+
+    assert vector._values == [6, 7, 3]
+
+
+def test___vector_with_data___set_item_at_slice_with_generator___values_set_correctly() -> None:
+    def get_values() -> Iterable[int]:
+        yield 6
+        yield 7
+
+    vector = Vector([1, 2, 3], "volts")
+
+    vector[0:2] = get_values()
+
     assert vector._values == [6, 7, 3]
 
 
@@ -150,6 +200,7 @@ def test___vector_with_data___set_item_at_slice_to_empty_list___values_set_corre
     vector = Vector([1, 2, 3], "volts")
 
     vector[0:2] = []
+
     assert vector._values == [3]
 
 

--- a/tests/unit/vector/test_vector.py
+++ b/tests/unit/vector/test_vector.py
@@ -117,13 +117,13 @@ def test___invalid_data_value___create___raises_type_error(data_value: Any) -> N
 
 def test___invalid_generator_data_values___create___raises_type_error() -> None:
     def get_values() -> Iterable[Any]:
-        yield from [{"test_key", "test_value"}, 1.0, 2.0]
+        yield from [{"value_one", "value_two"}, 1.0, 2.0]
 
     with pytest.raises(TypeError) as exc:
         _ = Vector(get_values())
 
     assert exc.value.args[0].startswith("The vector input data must be a bool, int, float, or str.")
-    assert "{'test_key', 'test_value'}" in exc.value.args[0]
+    assert "value_one" in exc.value.args[0]
 
 
 def test___empty_generator_data_values___create___raises_type_error() -> None:

--- a/tests/unit/vector/test_vector.py
+++ b/tests/unit/vector/test_vector.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 import pickle
-from collections.abc import Iterable
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -69,7 +69,7 @@ def test___str_data_values___create___creates_with_str_data_and_default_units() 
 
 
 def test___generator_data_values___create___creates_with_data_and_default_units() -> None:
-    def get_values() -> Iterable[float]:
+    def get_values() -> Generator[float]:
         yield 20.2
         yield 30.3
         yield 40.4
@@ -116,7 +116,7 @@ def test___invalid_data_value___create___raises_type_error(data_value: Any) -> N
 
 
 def test___invalid_generator_data_values___create___raises_type_error() -> None:
-    def get_values() -> Iterable[Any]:
+    def get_values() -> Generator[Any]:
         yield from [{"value_one", "value_two"}, 1.0, 2.0]
 
     with pytest.raises(TypeError) as exc:
@@ -127,7 +127,7 @@ def test___invalid_generator_data_values___create___raises_type_error() -> None:
 
 
 def test___empty_generator_data_values___create___raises_type_error() -> None:
-    def get_values() -> Iterable[float]:
+    def get_values() -> Generator[float]:
         yield from []
 
     with pytest.raises(TypeError) as exc:
@@ -185,7 +185,7 @@ def test___vector_with_data___set_item_at_slice___values_set_correctly() -> None
 
 
 def test___vector_with_data___set_item_at_slice_with_generator___values_set_correctly() -> None:
-    def get_values() -> Iterable[int]:
+    def get_values() -> Generator[int]:
         yield 6
         yield 7
 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

This set of changes updates the `Vector` data type so that both `Vector` initialization and `__setitem__` support as input `Iterable` objects that can only be successfully iterated a single time, such as generator functions.

Prior to these changes, the behaviors of `Vector` were the following:

`__init__`:

```
    def get_values() -> Iterable[float]:
        yield 20.2
        yield 30.3
        yield 40.4

    test_vector = Vector(get_values())

    # Expected Behavior: test_vector holds [20.2, 30.3, 40.4]
    # Actual Behavior:   test_vector is empty
```

`__setitem__`:

```
    def get_values() -> Iterable[float]:
        yield 6.5
        yield 7.5

    test_vector = Vector([1.5, 2.5, 3.5], "volts")

    test_vector[0:2] = get_values()

    # Expected Behavior: test_vector now holds the following elements: [6.5, 7.5, 3.5]
    # Actual Behavior:   test_vector now holds the following elements: [3.5]

```
In essence, because the `Iterable` being supplied to `__init__` or `__setitem__` in these scenarios only supports being iterated once and the implementations of these methods were iterating over the provided `Iterable` **twice**, first for data validation and then again for actual value assignment, the actual value assignment was reading an `Iterable` that had already been exhausted. As a result, supplying an `Iterable` of such a form resulted in behavior as if an empty `Iterable` had been supplied into the method in question.

Since the `Vector` data type provides a type hint indicating that `Iterable[TScalar]` is the expected type for the `values`/`value` parameter in these cases, we should be robust in handling all `Iterable`s (including single-pass ones).

### Implementation

- Updated `__init__` to create a `list` of the supplied `values` *before* iterating through these values and performing element-level validation on them, rather than doing so after this validation has taken place
- Updated `__setitem__` to create a `list` wrapper for the incoming `Iterable` if the `Iterable` is not a `Sequence` (and we cannot be assured of multi-pass iteration support)

### Why should this Pull Request be merged?

This PR addresses a behavioral issue in which `Vector` was not handling certain types of `Iterable`s as input in an intuitive or expected manner.

### What testing has been done?

Added new test cases in `test_vector.py` covering usage of single-pass iterables with `__init__` and `__setitem__`