### PR TITLE
Bump main version to 1.2.0.dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nitypes"
 description = "Data types for NI Python APIs"
 license = "MIT"
 keywords = ["nitypes"]
-version = "1.1.0.dev4"
+version = "1.2.0.dev0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version in main to 1.2.0.dev0.

### Why should this Pull Request be merged?

We're about to release 1.1.0 so this avoids mistakes and confusion on the `main` version.

### What testing has been done?

PR
