### PR TITLE
Bump releases/1.1 version to 1.1.0 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "nitypes"
 description = "Data types for NI Python APIs"
 license = "MIT"
 keywords = ["nitypes"]
-version = "1.1.0.dev4"
+version = "1.1.0"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nitypes-python/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Bump the version in `releases/1.1` branch to 1.1.0 preparing us for release.

### Why should this Pull Request be merged?

Remove 'dev4' suffix to prepare for release of 1.1.0.

### What testing has been done?

PR
